### PR TITLE
Allowing to disable font caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/),
 and [PEP 440](https://www.python.org/dev/peps/pep-0440/).
 
+## [2.4.2] - not released yet
+### Added
+- disable font caching when `fpdf.FPDF` constructor invoked with `font_cache_dir=None`
+
 ## [2.4.1] - 2021-06-12
 ### Fixed
 - erroneous page breaks occured for full-width / full-height images

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -203,6 +203,7 @@ class FPDF:
                 (width, height) expressed in the given unit. Default to "a4".
             font_cache_dir (Path or str): directory where pickle files
                 for TTF font files are kept.
+                `None` disables font chaching.
                 The default is `True`, meaning the current folder.
         """
         # Initialization of properties
@@ -1039,10 +1040,13 @@ class FPDF:
             else:
                 raise FileNotFoundError(f"TTF Font file not found: {fname}")
 
-            cache_dir = (
-                Path() if self.font_cache_dir is True else Path(self.font_cache_dir)
-            )
-            unifilename = cache_dir / f"{ttffilename.stem}.pkl"
+            if self.font_cache_dir is None:
+                cache_dir = unifilename = None
+            else:
+                cache_dir = (
+                    Path() if self.font_cache_dir is True else Path(self.font_cache_dir)
+                )
+                unifilename = cache_dir / f"{ttffilename.stem}.pkl"
 
             # include numbers in the subset! (if alias present)
             sbarr = list(range(57 if self.str_alias_nb_pages else 32))
@@ -2708,7 +2712,10 @@ class FPDF:
                 self.mtd(font)
 
     def _putTTfontwidths(self, font, maxUni):
-        cw127fname = Path(font["unifilename"]).with_suffix(".cw127.pkl")
+        if font["unifilename"] is None:
+            cw127fname = None
+        else:
+            cw127fname = Path(font["unifilename"]).with_suffix(".cw127.pkl")
         font_dict = load_cache(cw127fname)
         if font_dict:
             rangeid = font_dict["rangeid"]

--- a/test/fonts/test_add_font.py
+++ b/test/fonts/test_add_font.py
@@ -58,7 +58,7 @@ def test_deprecation_warning_for_FPDF_CACHE_DIR():
 
 
 def test_add_font_unicode_with_path_fname_ok(tmp_path):
-    for font_cache_dir in (True, tmp_path):
+    for font_cache_dir in (True, tmp_path, None):
         pdf = FPDF(font_cache_dir=font_cache_dir)
         font_file_path = HERE / "../fonts/Roboto-Regular.ttf"
         pdf.add_font("Roboto-Regular", fname=font_file_path, uni=True)
@@ -69,7 +69,7 @@ def test_add_font_unicode_with_path_fname_ok(tmp_path):
 
 
 def test_add_font_unicode_with_str_fname_ok(tmp_path):
-    for font_cache_dir in (True, str(tmp_path)):
+    for font_cache_dir in (True, str(tmp_path), None):
         pdf = FPDF(font_cache_dir=font_cache_dir)
         font_file_path = HERE / "../fonts/Roboto-Regular.ttf"
         pdf.add_font("Roboto-Regular", fname=str(font_file_path), uni=True)


### PR DESCRIPTION
This feature mimics the behaviour of `FPDF_CACHE_MODE = 1` which has been deprecated. Set `font_cache_dir = None` to disable all caching.