### PR TITLE
Docs: Add Tutorial 4 to Tutorial.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Documentation:
 --------------
 
 - [Documentation Home](https://pyfpdf.github.io/fpdf2/)
-- [Tutorial](https://pyfpdf.github.io/fpdf2/Tutorial.html) (Spanish translation available)
+- [Tutorial](https://pyfpdf.github.io/fpdf2/Tutorial.html) ([Spanish translation available](https://pyfpdf.github.io/fpdf2/Tutorial-es.html))
 - Release notes: [CHANGELOG.md](https://github.com/PyFPDF/fpdf2/blob/master/CHANGELOG.md)
 
 You can also have a look at the `tests/`, they're great usage examples!

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -221,6 +221,8 @@ pdf.output('tuto3.pdf')
 
 [Demo](https://github.com/PyFPDF/fpdf2/raw/master/tutorial/tuto3.pdf)
 
+[Jules Verne text](https://github.com/PyFPDF/fpdf2/raw/master/tutorial/20k_c1.txt)
+
 The [get_string_width](fpdf/fpdf.html#fpdf.fpdf.FPDF.get_string_width) method allows determining
 the length of a string in the current font, which is used here to calculate the
 position and the width of the frame surrounding the title. Then colors are set
@@ -242,3 +244,115 @@ Two document properties are defined: the title
 First is to open the document directly with Acrobat Reader, go to the File menu
 and choose the Document Properties option. The second, also available from the
 plug-in, is to right-click and select Document Properties.
+
+## Tuto 4 - Multi Columns ##
+
+ This example is a variant of the previous one, showing how to lay the text across multiple columns.
+
+```python
+ from fpdf import FPDF
+
+
+class PDF(FPDF):
+    # Current column
+    col = 0
+    # Ordinate of column start
+    y0 = 0
+
+    def header(self):
+        # Page header
+        self.set_font("helvetica", "B", 15)
+        w = self.get_string_width(title) + 6
+        self.set_x((210 - w) / 2)
+        self.set_draw_color(0, 80, 180)
+        self.set_fill_color(230, 230, 0)
+        self.set_text_color(220, 50, 50)
+        self.set_line_width(1)
+        self.cell(w, 9, title, 1, 1, "C", True)
+        self.ln(10)
+        # Save ordinate
+        self.y0 = self.get_y()
+
+    def footer(self):
+        # Page footer
+        self.set_y(-15)
+        self.set_font("helvetica", "I", 8)
+        self.set_text_color(128)
+        self.cell(0, 10, f"Page {self.page_no()}", 0, 0, "C")
+
+    def set_col(self, col):
+        # Set position at a given column
+        self.col = col
+        x = 10 + col * 65
+        self.set_left_margin(x)
+        self.set_x(x)
+
+    @property
+    def accept_page_break(self):
+        if self.col < 2:
+            # Go to next column:
+            self.set_col(self.col + 1)
+            # Set ordinate to top:
+            self.set_y(self.y0)
+            # Stay on the same page:
+            return False
+        # Go back to first column:
+        self.set_col(0)
+        # Trigger a page break:
+        return True
+
+    def chapter_title(self, num, label):
+        # Title
+        self.set_font("helvetica", "", 12)
+        self.set_fill_color(200, 220, 255)
+        self.cell(0, 6, f"Chapter {num} : {label}", 0, 1, "L", True)
+        self.ln(4)
+        # Save ordinate
+        self.y0 = self.get_y()
+
+    def chapter_body(self, name):
+        # Read text file
+        with open(name, "rb") as fh:
+            txt = fh.read().decode("latin-1")
+        # Font
+        self.set_font("Times", size=12)
+        # Output text in a 6 cm width column
+        self.multi_cell(60, 5, txt)
+        self.ln()
+        # Mention
+        self.set_font(style="I")
+        self.cell(0, 5, "(end of excerpt)")
+        # Go back to first column
+        self.set_col(0)
+
+    def print_chapter(self, num, title, name):
+        # Add chapter
+        self.add_page()
+        self.chapter_title(num, title)
+        self.chapter_body(name)
+
+
+pdf = PDF()
+title = "20000 Leagues Under the Seas"
+pdf.set_title(title)
+pdf.set_author("Jules Verne")
+pdf.print_chapter(1, "A RUNAWAY REEF", "20k_c1.txt")
+pdf.print_chapter(2, "THE PROS AND CONS", "20k_c1.txt")
+pdf.output("tuto4.pdf")
+```
+
+[Demo](https://github.com/PyFPDF/fpdf2/raw/master/tutorial/tuto4.pdf)
+
+[Jules Verne text](https://github.com/PyFPDF/fpdf2/raw/master/tutorial/20k_c1.txt)
+
+The key difference from the previous tutorial is the use of the 
+[accept_page_break](fpdf/fpdf.html#fpdf.fpdf.FPDF.accept_page_break) and the set_col methods.
+
+Using the [accept_page_break](fpdf/fpdf.html#fpdf.fpdf.FPDF.accept_page_break) method, once 
+the cell crosses the bottom limit of the page, it will check the current column number. If it 
+is less than 2 (we chose to divide the page in three columns) it will call the set_col method, 
+increasing the column number and altering the position of the next column so the text may continue there.
+
+Once the bottom limit of the third column is reached, the 
+[accept_page_break](fpdf/fpdf.html#fpdf.fpdf.FPDF.accept_page_break) method will reset and go 
+back to the first column and trigger a page break.


### PR DESCRIPTION
This is related to issue #56 and #246.

I added the 4th tutorial to Tutorial.md, taking the code from fpdf/tutorial/tuto4.py. I also tested the code in my computer and it ran without any issues. 

I took some of the explanation text from tuto4.htm and added the links to documentation and the output pdf in a similar way as previous tutorials. I also expanded on the explanation a bit to make it clearer, but feel free to edit anything. 

I also included the link to the original Jules Verne text file which is used to fill the columns. 

Finally, in the readme file, I added a link to the Spanish version documentation at the top so it can be accessed more easily. 
