### PR TITLE
Basic mypy support

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install system dependencies ⚙️
         if: matrix.platform == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install ghostscript libjpeg-dev
+        run: sudo apt-get update && sudo apt-get install ghostscript libjpeg-dev swig
       - name: Install qpdf ⚙️
         if: matrix.platform == 'ubuntu-latest' && matrix.python-version != '3.9'
         # We run the unit tests WITHOUT qpdf for a single parallel execution / Python version:

--- a/fpdf/annotations.py
+++ b/fpdf/annotations.py
@@ -1,6 +1,6 @@
 import hashlib
 from datetime import datetime
-from typing import NamedTuple, Tuple, Union
+from typing import NamedTuple, Tuple, Union, Optional, Dict
 
 from .actions import Action
 from .enums import AnnotationFlag, AnnotationName, FileAttachmentAnnotationName
@@ -31,18 +31,18 @@ class AnnotationMixin:
         width: int,
         height: int,
         flags: Tuple[AnnotationFlag] = DEFAULT_ANNOT_FLAGS,
-        contents: str = None,
-        dest: Destination = None,
-        action: Action = None,
-        color: tuple = None,
-        modification_time: datetime = None,
-        title: str = None,
-        quad_points: tuple = None,
+        contents: Optional[str] = None,
+        dest: Optional[Destination] = None,
+        action: Optional[Action] = None,
+        color: Optional[tuple] = None,
+        modification_time: Optional[datetime] = None,
+        title: Optional[str] = None,
+        quad_points: Optional[tuple] = None,
         border_width: int = 0,  # PDF readers support: displayed by Acrobat but not Sumatra
-        name: Union[AnnotationName, FileAttachmentAnnotationName] = None,
-        ink_list: Tuple[int] = (),  # for ink annotations
-        file_spec: str = None,
-        field_type: str = None,
+        name: Optional[Union[AnnotationName, FileAttachmentAnnotationName]] = None,
+        ink_list: Optional[Tuple[int]] = None,  # for ink annotations
+        file_spec: Optional[str] = None,
+        field_type: Optional[str] = None,
         value=None,
     ):
         self.type = Name("Annot")
@@ -123,14 +123,14 @@ class PDFEmbeddedFile(PDFContentStream):
         basename: str,
         contents: bytes,
         desc: str = "",
-        creation_date: datetime = None,
-        modification_date: datetime = None,
+        creation_date: Optional[datetime] = None,
+        modification_date: Optional[datetime] = None,
         compress: bool = False,
         checksum: bool = False,
     ):
         super().__init__(contents=contents, compress=compress)
         self.type = Name("EmbeddedFile")
-        params = {"/Size": len(contents)}
+        params: Dict[str, Union[int, str]] = {"/Size": len(contents)}
         if creation_date:
             params["/CreationDate"] = PDFDate(creation_date, with_tz=True).serialize()
         if modification_date:

--- a/fpdf/drawing.py
+++ b/fpdf/drawing.py
@@ -195,7 +195,7 @@ class DeviceRGB(
     OPERATOR = "rg"
     """The PDF drawing operator used to specify this type of color."""
 
-    def __new__(cls, r, g, b, a=None):
+    def __new__(cls, r: float, g: float, b: float, a: Optional[float] = None):
         if a is not None:
             _check_range(a)
 
@@ -240,7 +240,7 @@ class DeviceGray(
     OPERATOR = "g"
     """The PDF drawing operator used to specify this type of color."""
 
-    def __new__(cls, g, a=None):
+    def __new__(cls, g: float, a: Optional[float] = None):
         if a is not None:
             _check_range(a)
 
@@ -3240,7 +3240,7 @@ class PaintedPath:
     primitive path elements and `GraphicsContext`.
     """
 
-    def __init__(self, x=0, y=0):
+    def __init__(self, x: float = 0, y: float = 0) -> None:
         self._root_graphics_context = GraphicsContext()
         self._graphics_context = self._root_graphics_context
 

--- a/fpdf/drawing.py
+++ b/fpdf/drawing.py
@@ -1,7 +1,7 @@
 import copy, decimal, math, re
 from collections import OrderedDict
 from contextlib import contextmanager
-from typing import Optional, NamedTuple, Union
+from typing import Optional, NamedTuple, Union, Dict
 
 from .enums import (
     BlendMode,
@@ -15,7 +15,7 @@ from .enums import (
 from .syntax import Name, Raw
 from .util import escape_parens
 
-__pdoc__ = {"force_nodocument": False}
+__pdoc__: Dict[str, Union[bool, str]] = {"force_nodocument": False}
 
 
 def force_nodocument(item):
@@ -605,7 +605,7 @@ class Point(NamedTuple):
 
         return NotImplemented
 
-    __rmul__ = __mul__
+    __rmul__ = __mul__  # type: ignore[misc]
 
     @force_document
     def __truediv__(self, other):
@@ -983,7 +983,7 @@ class Transform(NamedTuple):
         return NotImplemented
 
     # scalar multiplication is commutative
-    __rmul__ = __mul__
+    __rmul__ = __mul__  # type: ignore[misc]
 
     @force_document
     def __matmul__(self, other):

--- a/fpdf/errors.py
+++ b/fpdf/errors.py
@@ -5,7 +5,7 @@ class FPDFException(Exception):
 class FPDFPageFormatException(FPDFException):
     """Error is thrown when a bad page format is given"""
 
-    def __init__(self, argument, unknown=False, one=False):
+    def __init__(self, argument, unknown: bool = False, one: bool = False):
         super().__init__()
         if unknown and one:
             raise TypeError(

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -19,13 +19,13 @@ from math import isclose
 from numbers import Number
 from os.path import splitext
 from pathlib import Path
-from typing import Callable, NamedTuple, Optional, Union
+from typing import Callable, NamedTuple, Optional, Union, List, Tuple
 
 try:
     from endesive import signer
     from cryptography.hazmat.primitives.serialization import pkcs12
 except ImportError:
-    pkcs12, signer = None, None
+    pkcs12, signer = None, None  # type: ignore[assignment]
 
 try:
     from PIL.Image import Image
@@ -34,7 +34,7 @@ except ImportError:
         "Pillow could not be imported - fpdf2 will not be able to add any image"
     )
 
-    class Image:
+    class Image:  # type: ignore[no-redef]
         # The class must exist for some isinstance checks below
         pass
 
@@ -148,7 +148,7 @@ class TitleStyle(FontFace):
         font_family: Optional[str] = None,
         font_style: Optional[str] = None,
         font_size_pt: Optional[int] = None,
-        color: Union[int, tuple] = None,  # grey scale or (red, green, blue),
+        color: Optional[Union[int, tuple]] = None,  # grey scale or (red, green, blue),
         underline: bool = False,
         t_margin: Optional[int] = None,
         l_margin: Optional[int] = None,
@@ -510,7 +510,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.r_margin = margin
 
-    def set_auto_page_break(self, auto, margin=0):
+    def set_auto_page_break(self, auto: bool, margin: float = 0.0):
         """
         Set auto page break mode and triggering bottom margin.
         By default, the mode is on and the bottom margin is 2 cm.
@@ -582,7 +582,7 @@ class FPDF(GraphicsStateMixin):
         if self._page_layout in (PageLayout.TWO_PAGE_LEFT, PageLayout.TWO_PAGE_RIGHT):
             self._set_min_pdf_version("1.5")
 
-    def set_compression(self, compress):
+    def set_compression(self, compress: bool):
         """
         Activates or deactivates page compression.
 
@@ -597,7 +597,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.compress = compress
 
-    def set_title(self, title):
+    def set_title(self, title: str):
         """
         Defines the title of the document.
 
@@ -606,7 +606,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.title = title
 
-    def set_lang(self, lang):
+    def set_lang(self, lang: str):
         """
         A language identifier specifying the natural language for all text in the document
         except where overridden by language specifications for structure elements or marked content.
@@ -620,7 +620,7 @@ class FPDF(GraphicsStateMixin):
         if lang:
             self._set_min_pdf_version("1.4")
 
-    def set_subject(self, subject):
+    def set_subject(self, subject: str):
         """
         Defines the subject of the document.
 
@@ -629,7 +629,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.subject = subject
 
-    def set_author(self, author):
+    def set_author(self, author: str):
         """
         Defines the author of the document.
 
@@ -638,7 +638,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.author = author
 
-    def set_keywords(self, keywords):
+    def set_keywords(self, keywords: str):
         """
         Associate keywords with the document
 
@@ -647,7 +647,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.keywords = keywords
 
-    def set_creator(self, creator):
+    def set_creator(self, creator: str):
         """
         Defines the creator of the document.
         This is typically the name of the application that generates the PDF.
@@ -673,7 +673,7 @@ class FPDF(GraphicsStateMixin):
             date = date.astimezone()
         self.creation_date = date
 
-    def set_xmp_metadata(self, xmp_metadata):
+    def set_xmp_metadata(self, xmp_metadata: str):
         if "<?xpacket" in xmp_metadata[:50]:
             raise ValueError(
                 "fpdf2 already performs XMP metadata wrapping in a <?xpacket> tag"
@@ -682,7 +682,7 @@ class FPDF(GraphicsStateMixin):
         if xmp_metadata:
             self._set_min_pdf_version("1.4")
 
-    def set_doc_option(self, opt, value):
+    def set_doc_option(self, opt: str, value: str):
         """
         Defines a document option.
 
@@ -704,7 +704,7 @@ class FPDF(GraphicsStateMixin):
             raise FPDFException(f'Unknown document option "{opt}"')
         self.core_fonts_encoding = value
 
-    def set_image_filter(self, image_filter):
+    def set_image_filter(self, image_filter: str):
         """
         Args:
             image_filter (str): name of a the image filter to use
@@ -723,7 +723,7 @@ class FPDF(GraphicsStateMixin):
         if image_filter == "JPXDecode":
             self._set_min_pdf_version("1.5")
 
-    def alias_nb_pages(self, alias="{nb}"):
+    def alias_nb_pages(self, alias: str = "{nb}"):
         """
         Defines an alias for the total number of pages.
         It will be substituted as the document is closed.
@@ -748,7 +748,12 @@ class FPDF(GraphicsStateMixin):
         self.str_alias_nb_pages = alias
 
     def add_page(
-        self, orientation="", format="", same=False, duration=0, transition=None
+        self,
+        orientation: str = "",
+        format: str = "",
+        same: bool = False,
+        duration: float = 0.0,
+        transition=None,
     ):
         """
         Adds a new page to the document.
@@ -909,11 +914,11 @@ class FPDF(GraphicsStateMixin):
         in a subclass to implement your own rendering logic.
         """
 
-    def page_no(self):
+    def page_no(self) -> int:
         """Get the current page number"""
         return self.page
 
-    def set_draw_color(self, r, g=-1, b=-1):
+    def set_draw_color(self, r, g: int = -1, b: int = -1):
         """
         Defines the color used for all stroking operations (lines, rectangles and cell borders).
         It can be expressed in RGB components or grey scale.
@@ -929,7 +934,7 @@ class FPDF(GraphicsStateMixin):
         if self.page > 0:
             self._out(self.draw_color.serialize().upper())
 
-    def set_fill_color(self, r, g=-1, b=-1):
+    def set_fill_color(self, r, g: int = -1, b: int = -1):
         """
         Defines the color used for all filling operations (filled rectangles and cell backgrounds).
         It can be expressed in RGB components or grey scale.
@@ -980,7 +985,7 @@ class FPDF(GraphicsStateMixin):
             w += frag.get_width()
         return w
 
-    def set_line_width(self, width):
+    def set_line_width(self, width: float):
         """
         Defines the line width of all stroking operations (lines, rectangles and cell borders).
         By default, the value equals 0.2 mm.
@@ -993,7 +998,7 @@ class FPDF(GraphicsStateMixin):
         if self.page > 0:
             self._out(f"{width * self.k:.2f} w")
 
-    def set_page_background(self, background):
+    def set_page_background(self, background: str):
         """
         Sets a background color or image to be drawn every time `FPDF.add_page()` is called, or removes a previously set background.
         The method can be called before the first page is created and the value is retained from page to page.
@@ -1764,7 +1769,7 @@ class FPDF(GraphicsStateMixin):
 
         self.fonts[fontkey] = TTFFont(self, font_file_path, fontkey, style)
 
-    def set_font(self, family=None, style="", size=0):
+    def set_font(self, family: Optional[str] = None, style: str = "", size: float = 0):
         """
         Sets the font used to print character strings.
         It is mandatory to call this method at least once before printing text.
@@ -1848,7 +1853,7 @@ class FPDF(GraphicsStateMixin):
         if self.page > 0:
             self._out(f"BT /F{self.current_font.i} {self.font_size_pt:.2f} Tf ET")
 
-    def set_font_size(self, size):
+    def set_font_size(self, size: float):
         """
         Configure the font size in points
 
@@ -1865,7 +1870,7 @@ class FPDF(GraphicsStateMixin):
                 )
             self._out(f"BT /F{self.current_font.i} {self.font_size_pt:.2f} Tf ET")
 
-    def set_char_spacing(self, spacing):
+    def set_char_spacing(self, spacing: float):
         """
         Sets horizontal character spacing.
         A positive value increases the space between characters, a negative value
@@ -1881,7 +1886,7 @@ class FPDF(GraphicsStateMixin):
         if self.page > 0:
             self._out(f"BT {spacing:.2f} Tc ET")
 
-    def set_stretching(self, stretching):
+    def set_stretching(self, stretching: float):
         """
         Sets horizontal font stretching.
         By default, no stretching is set (which is equivalent to a value of 100).
@@ -1895,7 +1900,7 @@ class FPDF(GraphicsStateMixin):
         if self.page > 0:
             self._out(f"BT {stretching:.2f} Tz ET")
 
-    def set_fallback_fonts(self, fallback_fonts, exact_match=True):
+    def set_fallback_fonts(self, fallback_fonts: List[str], exact_match: bool = True):
         """
         Allows you to specify a list of fonts to be used if any character is not available on the font currently set.
         Detailed documentation: https://pyfpdf.github.io/fpdf2/Unicode.html#fallback-fonts
@@ -1923,7 +1928,7 @@ class FPDF(GraphicsStateMixin):
         self._fallback_font_ids = tuple(fallback_font_ids)
         self._fallback_font_exact_match = exact_match
 
-    def add_link(self, y=0, x=0, page=-1, zoom="null"):
+    def add_link(self, y: float = 0, x: float = 0, page: int = -1, zoom: str = "null"):
         """
         Creates a new internal link and returns its identifier.
         An internal link is a clickable area which directs to another place within the document.
@@ -1951,7 +1956,9 @@ class FPDF(GraphicsStateMixin):
         self.links[link_index] = link
         return link_index
 
-    def set_link(self, link, y=0, x=0, page=-1, zoom="null"):
+    def set_link(
+        self, link: int, y: float = 0, x: float = 0, page: int = -1, zoom: str = "null"
+    ):
         """
         Defines the page and position a link points to.
 
@@ -1976,7 +1983,16 @@ class FPDF(GraphicsStateMixin):
         link.zoom = zoom
 
     @check_page
-    def link(self, x, y, w, h, link, alt_text=None, border_width=0):
+    def link(
+        self,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        link,
+        alt_text: Optional[str] = None,
+        border_width: int = 0,
+    ):
         """
         Puts a link annotation on a rectangular area of the page.
         Text or image links are generally put via `FPDF.cell`,
@@ -2027,9 +2043,9 @@ class FPDF(GraphicsStateMixin):
     def embed_file(
         self,
         file_path=None,
-        bytes=None,
-        basename=None,
-        modification_date=None,
+        bytes: Optional[bytes] = None,
+        basename: Optional[str] = None,
+        modification_date: Optional[datetime] = None,
         **kwargs,
     ):
         """
@@ -2083,7 +2099,15 @@ class FPDF(GraphicsStateMixin):
 
     @check_page
     def file_attachment_annotation(
-        self, file_path, x, y, w=1, h=1, name=None, flags=DEFAULT_ANNOT_FLAGS, **kwargs
+        self,
+        file_path,
+        x: float,
+        y: float,
+        w: float = 1,
+        h: float = 1,
+        name=None,
+        flags=DEFAULT_ANNOT_FLAGS,
+        **kwargs,
     ):
         """
         Puts a file attachment annotation on a rectangular area of the page.
@@ -2121,7 +2145,14 @@ class FPDF(GraphicsStateMixin):
 
     @check_page
     def text_annotation(
-        self, x, y, text, w=1, h=1, name=None, flags=DEFAULT_ANNOT_FLAGS
+        self,
+        x: float,
+        y: float,
+        text: str,
+        w: float = 1,
+        h: float = 1,
+        name=None,
+        flags=DEFAULT_ANNOT_FLAGS,
     ):
         """
         Puts a text annotation on a rectangular area of the page.
@@ -2149,7 +2180,7 @@ class FPDF(GraphicsStateMixin):
         return annotation
 
     @check_page
-    def add_action(self, action, x, y, w, h):
+    def add_action(self, action, x: float, y: float, w: float, h: float):
         """
         Puts an Action annotation on a rectangular area of the page.
 
@@ -2173,7 +2204,12 @@ class FPDF(GraphicsStateMixin):
 
     @contextmanager
     def highlight(
-        self, text, title="", type="Highlight", color=(1, 1, 0), modification_time=None
+        self,
+        text: str,
+        title: str = "",
+        type="Highlight",
+        color: Tuple[float, float, float] = (1, 1, 0),
+        modification_time: Optional[datetime] = None,
     ):
         """
         Context manager that adds a single highlight annotation based on the text lines inserted
@@ -2211,12 +2247,12 @@ class FPDF(GraphicsStateMixin):
     def add_text_markup_annotation(
         self,
         type,
-        text,
+        text: str,
         quad_points,
         title="",
-        color=(1, 1, 0),
-        modification_time=None,
-        page=None,
+        color: Tuple[float, float, float] = (1, 1, 0),
+        modification_time: Optional[datetime] = None,
+        page: Optional[int] = None,
     ):
         """
         Adds a text markup annotation on some quadrilateral areas of the page.
@@ -2262,7 +2298,12 @@ class FPDF(GraphicsStateMixin):
 
     @check_page
     def ink_annotation(
-        self, coords, contents="", title="", color=(1, 1, 0), border_width=1
+        self,
+        coords,
+        contents: str = "",
+        title: str = "",
+        color: Tuple[float, float, float] = (1, 1, 0),
+        border_width: int = 1,
     ):
         """
         Adds add an ink annotation on the page.
@@ -2297,7 +2338,7 @@ class FPDF(GraphicsStateMixin):
         return annotation
 
     @check_page
-    def text(self, x, y, txt=""):
+    def text(self, x: float, y: float, txt: str = ""):
         """
         Prints a character string. The origin is on the left of the first character,
         on the baseline. This method allows placing a string precisely on the page,
@@ -2341,7 +2382,9 @@ class FPDF(GraphicsStateMixin):
         self._out(" ".join(sl))
 
     @check_page
-    def rotate(self, angle, x=None, y=None):
+    def rotate(
+        self, angle: float, x: Optional[float] = None, y: Optional[float] = None
+    ):
         """
         .. deprecated:: 2.1.0
             Use `FPDF.rotation()` instead.
@@ -2717,8 +2760,8 @@ class FPDF(GraphicsStateMixin):
     def _render_styled_text_line(
         self,
         text_line: TextLine,
-        w: float = None,
-        h: float = None,
+        w: Optional[float] = None,
+        h: Optional[float] = None,
         border: Union[str, int] = 0,
         new_x: XPos = XPos.RIGHT,
         new_y: YPos = YPos.TOP,
@@ -2783,6 +2826,8 @@ class FPDF(GraphicsStateMixin):
                     "A 'text_line' parameter with fragments must be provided if 'w' is None"
                 )
             w = styled_txt_width + self.c_margin + self.c_margin
+        assert w is not None  # this is always true, make mypy happy
+
         if center:
             self.x = (
                 self.w / 2 if align == Align.X else self.l_margin + (self.epw - w) / 2
@@ -3447,7 +3492,7 @@ class FPDF(GraphicsStateMixin):
         if not text_lines:  # ensure we display at least one cell - cf. issue #349
             text_lines = [
                 TextLine(
-                    "",
+                    [],
                     text_width=0,
                     number_of_spaces=0,
                     justify=False,
@@ -3496,7 +3541,7 @@ class FPDF(GraphicsStateMixin):
         if should_render_bottom_blank_cell:
             new_page = self._render_styled_text_line(
                 TextLine(
-                    "",
+                    [],
                     text_width=0,
                     number_of_spaces=0,
                     justify=False,
@@ -3537,7 +3582,7 @@ class FPDF(GraphicsStateMixin):
             self.underline = prev_underline
 
         output = MethodReturnValue.coerce(output)
-        return_value = ()
+        return_value: tuple = ()
         if output & MethodReturnValue.PAGE_BREAK:
             return_value += (page_break_triggered,)
         if output & MethodReturnValue.LINES:
@@ -3557,7 +3602,7 @@ class FPDF(GraphicsStateMixin):
     @check_page
     def write(
         self,
-        h: float = None,
+        h: Optional[float] = None,
         txt: str = "",
         link: str = "",
         print_sh: bool = False,
@@ -4059,7 +4104,7 @@ class FPDF(GraphicsStateMixin):
         self.x = self.l_margin
         self.y = y if y >= 0 else self.h + y
 
-    def set_xy(self, x, y):
+    def set_xy(self, x: float, y: float):
         """
         Defines the abscissa and ordinate of the current position.
         If the values provided are negative, they are relative respectively to the right and bottom of the page.
@@ -4071,7 +4116,7 @@ class FPDF(GraphicsStateMixin):
         self.set_y(y)
         self.set_x(x)
 
-    def normalize_text(self, txt):
+    def normalize_text(self, txt: str):
         """Check that text input is in the correct format/encoding"""
         # - for TTF unicode fonts: unicode object (utf8 encoding)
         # - for built-in fonts: string instances (encoding: latin-1, cp1252)

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -19,7 +19,9 @@ from math import isclose
 from numbers import Number
 from os.path import splitext
 from pathlib import Path
-from typing import Callable, NamedTuple, Optional, Union, List, Tuple
+from typing import Callable, NamedTuple, Optional, Union, List, Tuple, Any
+
+from .drawing import DeviceGray, DeviceRGB
 
 try:
     from endesive import signer
@@ -235,10 +237,10 @@ class FPDF(GraphicsStateMixin):
 
     def __init__(
         self,
-        orientation="portrait",
-        unit="mm",
-        format="A4",
-        font_cache_dir="DEPRECATED",
+        orientation: str = "portrait",
+        unit: Union[str, int, float] = "mm",
+        format: str = "A4",
+        font_cache_dir: Union[Path, str] = "DEPRECATED",
     ):
         """
         Args:
@@ -411,11 +413,11 @@ class FPDF(GraphicsStateMixin):
         text = unescape(text)  # To deal with HTML entities
         html2pdf.feed(text)
 
-    def _set_min_pdf_version(self, version):
+    def _set_min_pdf_version(self, version: str) -> None:
         self.pdf_version = max(self.pdf_version, version)
 
     @property
-    def is_ttf_font(self):
+    def is_ttf_font(self) -> bool:
         return self.current_font and self.current_font.type == "TTF"
 
     @property
@@ -461,7 +463,7 @@ class FPDF(GraphicsStateMixin):
         self.set_margins(margin, margin)
         self.set_auto_page_break(self.auto_page_break, margin)
 
-    def set_margins(self, left, top, right=-1):
+    def set_margins(self, left: float, top: float, right: float = -1):
         """
         Sets the document left, top & optionaly right margins to the same value.
         By default, they equal 1 cm.
@@ -480,7 +482,7 @@ class FPDF(GraphicsStateMixin):
             right = left
         self.r_margin = right
 
-    def set_left_margin(self, margin):
+    def set_left_margin(self, margin: float):
         """
         Sets the document left margin.
         Also sets the current FPDF.x on the page to this minimum horizontal position.
@@ -492,7 +494,7 @@ class FPDF(GraphicsStateMixin):
             self.x = margin
         self.l_margin = margin
 
-    def set_top_margin(self, margin):
+    def set_top_margin(self, margin: float):
         """
         Sets the document top margin.
 
@@ -501,7 +503,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.t_margin = margin
 
-    def set_right_margin(self, margin):
+    def set_right_margin(self, margin: float):
         """
         Sets the document right margin.
 
@@ -533,7 +535,7 @@ class FPDF(GraphicsStateMixin):
             else (self.dh_pt, self.dw_pt)
         )
 
-    def _set_orientation(self, orientation, page_width_pt, page_height_pt):
+    def _set_orientation(self, orientation: str, page_width_pt, page_height_pt):
         orientation = orientation.lower()
         if orientation in ("p", "portrait"):
             self.cur_orientation = "P"
@@ -548,7 +550,7 @@ class FPDF(GraphicsStateMixin):
         self.w = self.w_pt / self.k
         self.h = self.h_pt / self.k
 
-    def set_display_mode(self, zoom, layout="continuous"):
+    def set_display_mode(self, zoom: Union[str, int], layout="continuous"):
         """
         Defines the way the document is to be displayed by the viewer.
 
@@ -950,7 +952,12 @@ class FPDF(GraphicsStateMixin):
         if self.page > 0:
             self._out(self.fill_color.serialize().lower())
 
-    def set_text_color(self, r, g=-1, b=-1):
+    def set_text_color(
+        self,
+        r: Union[int, Tuple[float, float, float], DeviceGray, DeviceRGB],
+        g=-1,
+        b=-1,
+    ):
         """
         Defines the color used for text.
         It can be expressed in RGB components or grey scale.
@@ -1393,7 +1400,7 @@ class FPDF(GraphicsStateMixin):
         style = RenderStyle.coerce(style)
         self._draw_ellipse(x, y, w, h, style.operator)
 
-    def _draw_ellipse(self, x, y, w, h, operator):
+    def _draw_ellipse(self, x: float, y: float, w: float, h: float, operator):
         cx = x + w / 2
         cy = y + h / 2
         rx = w / 2
@@ -3071,7 +3078,7 @@ class FPDF(GraphicsStateMixin):
 
         return page_break_triggered
 
-    def _add_quad_points(self, x, y, w, h):
+    def _add_quad_points(self, x: float, y: float, w: float, h: float):
         self._text_quad_points[self.page].extend(
             [
                 x * self.k,
@@ -3085,7 +3092,7 @@ class FPDF(GraphicsStateMixin):
             ]
         )
 
-    def _preload_font_styles(self, txt, markdown):
+    def _preload_font_styles(self, txt: str, markdown: bool):
         """
         When Markdown styling is enabled, we require secondary fonts
         to ender text in bold & italics.
@@ -3117,7 +3124,7 @@ class FPDF(GraphicsStateMixin):
         self.page = page
         return styled_txt_frags
 
-    def _parse_chars(self, txt):
+    def _parse_chars(self, txt: str):
         "Check if the font has all the necessary glyphs. If a glyph from a fallback font is used, break into fragments"
         fragments = []
         txt_frag = []
@@ -3285,12 +3292,12 @@ class FPDF(GraphicsStateMixin):
             return True
         return False
 
-    def _perform_page_break(self):
+    def _perform_page_break(self) -> None:
         x = self.x
         self.add_page(same=True)
         self.x = x  # restore x but not y after drawing header
 
-    def _has_next_page(self):
+    def _has_next_page(self) -> bool:
         return self.pages_count > self.page
 
     @contextmanager
@@ -4071,11 +4078,11 @@ class FPDF(GraphicsStateMixin):
         self.x = self.l_margin
         self.y += self._lasth if h is None else h
 
-    def get_x(self):
+    def get_x(self) -> float:
         """Returns the abscissa of the current position."""
         return self.x
 
-    def set_x(self, x):
+    def set_x(self, x: float) -> None:
         """
         Defines the abscissa of the current position.
         If the value provided is negative, it is relative to the right of the page.
@@ -4085,7 +4092,7 @@ class FPDF(GraphicsStateMixin):
         """
         self.x = x if x >= 0 else self.w + x
 
-    def get_y(self):
+    def get_y(self) -> float:
         """Returns the ordinate of the current position."""
         if self._in_unbreakable:
             raise FPDFException(
@@ -4093,7 +4100,7 @@ class FPDF(GraphicsStateMixin):
             )
         return self.y
 
-    def set_y(self, y):
+    def set_y(self, y: float) -> None:
         """
         Moves the current abscissa back to the left margin and sets the ordinate.
         If the value provided is negative, it is relative to the bottom of the page.
@@ -4133,13 +4140,13 @@ class FPDF(GraphicsStateMixin):
 
     def sign_pkcs12(
         self,
-        pkcs_filepath,
+        pkcs_filepath: str,
         password=None,
-        hashalgo="sha256",
-        contact_info=None,
-        location=None,
-        signing_time=None,
-        reason=None,
+        hashalgo: str = "sha256",
+        contact_info: Optional[str] = None,
+        location: Optional[str] = None,
+        signing_time: Optional[datetime] = None,
+        reason: Optional[str] = None,
         flags=(AnnotationFlag.PRINT, AnnotationFlag.LOCKED),
     ):
         """
@@ -4182,11 +4189,11 @@ class FPDF(GraphicsStateMixin):
         key,
         cert,
         extra_certs=(),
-        hashalgo="sha256",
-        contact_info=None,
-        location=None,
-        signing_time=None,
-        reason=None,
+        hashalgo: str = "sha256",
+        contact_info: Optional[str] = None,
+        location: Optional[str] = None,
+        signing_time: Optional[datetime] = None,
+        reason: Optional[str] = None,
         flags=(AnnotationFlag.PRINT, AnnotationFlag.LOCKED),
     ):
         """
@@ -4380,7 +4387,7 @@ class FPDF(GraphicsStateMixin):
                 x += line_width
 
     @check_page
-    def code39(self, txt, x, y, w=1.5, h=5):
+    def code39(self, txt: str, x: float, y: float, w: float = 1.5, h: float = 5):
         """Barcode 3of9"""
         dim = {"w": w, "n": w / 3}
         if not txt.startswith("*") or not txt.endswith("*"):
@@ -4448,7 +4455,7 @@ class FPDF(GraphicsStateMixin):
 
     @check_page
     @contextmanager
-    def rect_clip(self, x, y, w, h):
+    def rect_clip(self, x: float, y: float, w: float, h: float):
         """
         Context manager that defines a rectangular crop zone,
         useful to render only part of an image.
@@ -4470,7 +4477,7 @@ class FPDF(GraphicsStateMixin):
 
     @check_page
     @contextmanager
-    def elliptic_clip(self, x, y, w, h):
+    def elliptic_clip(self, x: float, y: float, w: float, h: float):
         """
         Context manager that defines an elliptic crop zone,
         useful to render only part of an image.
@@ -4488,7 +4495,7 @@ class FPDF(GraphicsStateMixin):
 
     @check_page
     @contextmanager
-    def round_clip(self, x, y, r):
+    def round_clip(self, x: float, y: float, r: float):
         """
         Context manager that defines a circular crop zone,
         useful to render only part of an image.
@@ -4548,7 +4555,7 @@ class FPDF(GraphicsStateMixin):
         recorder.rewind()
 
     @check_page
-    def insert_toc_placeholder(self, render_toc_function, pages=1):
+    def insert_toc_placeholder(self, render_toc_function, pages: int = 1):
         """
         Configure Table Of Contents rendering at the end of the document generation,
         and reserve some vertical space right now in order to insert it.
@@ -4578,13 +4585,13 @@ class FPDF(GraphicsStateMixin):
 
     def set_section_title_styles(
         self,
-        level0,
-        level1=None,
-        level2=None,
-        level3=None,
-        level4=None,
-        level5=None,
-        level6=None,
+        level0: TitleStyle,
+        level1: Optional[TitleStyle] = None,
+        level2: Optional[TitleStyle] = None,
+        level3: Optional[TitleStyle] = None,
+        level4: Optional[TitleStyle] = None,
+        level5: Optional[TitleStyle] = None,
+        level6: Optional[TitleStyle] = None,
     ):
         """
         Defines a style for section titles.
@@ -4615,7 +4622,7 @@ class FPDF(GraphicsStateMixin):
         }
 
     @check_page
-    def start_section(self, name, level=0, strict=True):
+    def start_section(self, name: str, level: int = 0, strict: bool = True):
         """
         Start a section in the document outline.
         If section_title_styles have been configured,
@@ -4740,7 +4747,11 @@ class FPDF(GraphicsStateMixin):
         table.render()
 
     def output(
-        self, name="", dest="", linearize=False, output_producer_class=OutputProducer
+        self,
+        name: str = "",
+        dest: str = "",
+        linearize: bool = False,
+        output_producer_class: type = OutputProducer,
     ):
         """
         Output PDF to some destination.
@@ -4800,7 +4811,7 @@ def _convert_to_drawing_color(r, g, b):
     return drawing.DeviceRGB(r / 255, g / 255, b / 255)
 
 
-def _is_svg(bytes):
+def _is_svg(bytes) -> bool:
     return bytes.startswith(b"<?xml ") or bytes.startswith(b"<svg ")
 
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -19,7 +19,7 @@ from math import isclose
 from numbers import Number
 from os.path import splitext
 from pathlib import Path
-from typing import Callable, NamedTuple, Optional, Union, List, Tuple, Any
+from typing import Callable, NamedTuple, Optional, Union, List, Tuple
 
 from .drawing import DeviceGray, DeviceRGB
 

--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -17,7 +17,7 @@ try:
         # pylint: disable=no-member
         RESAMPLE = Image.ANTIALIAS
 except ImportError:
-    Image = None
+    Image = None  # type: ignore[assignment]
 
 from .errors import FPDFException
 

--- a/fpdf/outline.py
+++ b/fpdf/outline.py
@@ -34,8 +34,8 @@ class OutlineItemDictionary(PDFObject):
     def __init__(
         self,
         title: str,
-        dest: Destination = None,
-        struct_elem: StructElem = None,
+        dest: Optional[Destination] = None,
+        struct_elem: Optional[StructElem] = None,
     ):
         super().__init__()
         self.title = PDFString(title, encrypt=True)

--- a/fpdf/recorder.py
+++ b/fpdf/recorder.py
@@ -24,7 +24,7 @@ class FPDFRecorder:
     when generating large PDFs, doubling memory usage may be troublesome.
     """
 
-    def __init__(self, pdf, accept_page_break=True):
+    def __init__(self, pdf, accept_page_break: bool = True) -> None:
         self.pdf = pdf
         self._initial = deepcopy(self.pdf.__dict__)
         self._calls = []
@@ -41,7 +41,7 @@ class FPDFRecorder:
         self.pdf.__dict__ = self._initial
         self._initial = deepcopy(self.pdf.__dict__)
 
-    def replay(self):
+    def replay(self) -> None:
         for call in self._calls:
             func, args, kwargs = call
             try:
@@ -59,7 +59,7 @@ class FPDFRecorder:
 
 
 class CallRecorder:
-    def __init__(self, func, calls):
+    def __init__(self, func, calls) -> None:
         self._func = func
         self._calls = calls
 

--- a/fpdf/sign.py
+++ b/fpdf/sign.py
@@ -1,6 +1,7 @@
 "Document signature generation"
 import hashlib
 from datetime import timezone
+from typing import Optional
 from unittest.mock import patch
 
 from .syntax import build_obj_dict, Name
@@ -9,7 +10,13 @@ from .util import buffer_subst
 
 
 class Signature:
-    def __init__(self, contact_info=None, location=None, m=None, reason=None):
+    def __init__(
+        self,
+        contact_info: Optional[str] = None,
+        location: Optional[str] = None,
+        m: Optional[str] = None,
+        reason: Optional[str] = None,
+    ):
         self.type = Name("Sig")
         self.filter = Name("Adobe.PPKLite")
         self.sub_filter = Name("adbe.pkcs7.detached")

--- a/fpdf/structure_tree.py
+++ b/fpdf/structure_tree.py
@@ -9,7 +9,7 @@ Quoting the PDF spec:
 > located by means of the **StructTreeRoot** entry in the document catalog.
 """
 from collections import defaultdict
-from typing import List, Union
+from typing import List, Union, Optional
 
 from .syntax import PDFObject, PDFString, PDFArray
 
@@ -73,9 +73,9 @@ class StructElem(PDFObject):
         struct_type: str,
         parent: PDFObject,
         kids: Union[List[int], List["StructElem"]],
-        page_number: int = None,
-        title: str = None,
-        alt: str = None,
+        page_number: Optional[int] = None,
+        title: Optional[str] = None,
+        alt: Optional[str] = None,
     ):
         super().__init__()
         self.type = "/StructElem"
@@ -107,9 +107,9 @@ class StructureTreeBuilder:
         self,
         page_number: int,
         struct_type: str,
-        mcid: int = None,
-        title: str = None,
-        alt_text: str = None,
+        mcid: Optional[int] = None,
+        title: Optional[str] = None,
+        alt_text: Optional[str] = None,
     ):
         struct_parents_id = self.spid_per_page_number.get(page_number)
         if struct_parents_id is None:

--- a/fpdf/syntax.py
+++ b/fpdf/syntax.py
@@ -344,7 +344,7 @@ class Destination(ABC):
 
 
 class DestinationXYZ(Destination):
-    def __init__(self, page, top, left=0, zoom="null"):
+    def __init__(self, page, top, left: int = 0, zoom: str = "null"):
         self.page_number = page
         self.top = top
         self.left = left

--- a/fpdf/template.py
+++ b/fpdf/template.py
@@ -5,16 +5,17 @@ __copyright__ = "Copyright (C) 2010 Mariano Reingart"
 __license__ = "LGPL 3.0"
 
 import csv, locale, warnings
+from typing import Optional
 
 from .errors import FPDFException
 from .fpdf import FPDF
 
 
-def _rgb(col):
+def _rgb(col: int):
     return (col // 65536), (col // 256 % 256), (col % 256)
 
 
-def _rgb_as_str(col):
+def _rgb_as_str(col: int):
     r, g, b = _rgb(col)
     if (r == 0 and g == 0 and b == 0) or g == -1:
         return f"{r / 255:.3f} g"
@@ -532,7 +533,13 @@ class FlexTemplate:
         pdf.set_xy(x1, y1)
         pdf.write(5, text, link)
 
-    def render(self, offsetx=0.0, offsety=0.0, rotate=0.0, scale=1.0):
+    def render(
+        self,
+        offsetx: float = 0.0,
+        offsety: float = 0.0,
+        rotate: float = 0.0,
+        scale: float = 1.0,
+    ):
         """
         Add the contents of the template to the PDF document.
 
@@ -667,7 +674,7 @@ class Template(FlexTemplate):
         self.pdf.add_page()
 
     # pylint: disable=arguments-differ
-    def render(self, outfile=None, dest=None):
+    def render(self, outfile: Optional[str] = None, dest: Optional[str] = None):
         """
         Finish the document and process all pending data.
 

--- a/fpdf/template.py
+++ b/fpdf/template.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright (C) 2010 Mariano Reingart"
 __license__ = "LGPL 3.0"
 
 import csv, locale, warnings
-from typing import Optional
+from typing import Optional, List
 
 from .errors import FPDFException
 from .fpdf import FPDF
@@ -30,7 +30,7 @@ class FlexTemplate:
     a document in any combination.
     """
 
-    def __init__(self, pdf, elements=None):
+    def __init__(self, pdf: FPDF, elements: Optional[List[dict]] = None) -> None:
         """
         Arguments:
 
@@ -60,7 +60,7 @@ class FlexTemplate:
         }
         self.texts = {}
 
-    def load_elements(self, elements):
+    def load_elements(self, elements: List[dict]):
         """
         Load a template definition.
 
@@ -152,7 +152,13 @@ class FlexTemplate:
             return False
         return None
 
-    def parse_csv(self, infile, delimiter=",", decimal_sep=".", encoding=None):
+    def parse_csv(
+        self,
+        infile: str,
+        delimiter: str = ",",
+        decimal_sep: str = ".",
+        encoding: Optional[str] = None,
+    ):
         """
         Load the template definition from a CSV file.
 
@@ -175,7 +181,7 @@ class FlexTemplate:
 
         """
 
-        def _varsep_float(s, default="0"):
+        def _varsep_float(s: str, default: str = "0"):
             """Convert to float with given decimal seperator"""
             # glad to have nonlocal scoping...
             return float((s.strip() or default).replace(decimal_sep, "."))
@@ -674,7 +680,7 @@ class Template(FlexTemplate):
         self.pdf.add_page()
 
     # pylint: disable=arguments-differ
-    def render(self, outfile: Optional[str] = None, dest: Optional[str] = None):
+    def render(self, outfile: Optional[str] = None, dest: Optional[str] = None):  # type: ignore[override]
         """
         Finish the document and process all pending data.
 

--- a/fpdf/util.py
+++ b/fpdf/util.py
@@ -44,7 +44,7 @@ def get_scale_factor(unit: Union[str, Number]) -> float:
         ValueError
     """
     if isinstance(unit, Number):
-        return float(unit)
+        return float(unit)  # type: ignore
 
     if unit == "pt":
         return 1
@@ -76,7 +76,7 @@ def convert_unit(
     """
     unit_conversion_factor = get_scale_factor(new_unit) / get_scale_factor(old_unit)
     if isinstance(to_convert, Iterable):
-        return tuple(convert_unit(i, 1, unit_conversion_factor) for i in to_convert)
+        return tuple(convert_unit(i, 1, unit_conversion_factor) for i in to_convert)  # type: ignore
     return to_convert / unit_conversion_factor
 
 
@@ -115,7 +115,7 @@ def get_process_rss_as_mib() -> Union[Number, None]:
     try:
         with open(f"/proc/{pid}/statm", encoding="utf8") as statm:
             return (
-                int(statm.readline().split()[1])
+                int(statm.readline().split()[1])  # type: ignore[return-value]
                 * os.sysconf("SC_PAGE_SIZE")
                 / 1024
                 / 1024
@@ -124,7 +124,7 @@ def get_process_rss_as_mib() -> Union[Number, None]:
         return None
 
 
-def get_process_heap_and_stack_sizes() -> Tuple[str]:
+def get_process_heap_and_stack_sizes() -> Tuple[str, str]:
     heap_size_in_mib, stack_size_in_mib = "<unavailable>", "<unavailable>"
     pid = os.getpid()
     try:
@@ -136,8 +136,8 @@ def get_process_heap_and_stack_sizes() -> Tuple[str]:
         words = line.split()
         addr_range, path = words[0], words[-1]
         addr_start, addr_end = addr_range.split("-")
-        addr_start, addr_end = int(addr_start, 16), int(addr_end, 16)
-        size = addr_end - addr_start
+        addr_start_int, addr_end_int = int(addr_start, 16), int(addr_end, 16)
+        size = addr_end_int - addr_start_int
         if path == "[heap]":
             heap_size_in_mib = f"{size / 1024 / 1024:.1f} MiB"
         elif path == "[stack]":
@@ -145,7 +145,7 @@ def get_process_heap_and_stack_sizes() -> Tuple[str]:
     return heap_size_in_mib, stack_size_in_mib
 
 
-def get_pymalloc_allocated_over_total_size() -> Tuple[str]:
+def get_pymalloc_allocated_over_total_size() -> str:
     """
     Get PyMalloc stats from sys._debugmallocstats()
     From experiments, not very reliable
@@ -189,6 +189,6 @@ def get_pillow_allocated_memory() -> str:
     # pylint: disable=c-extension-no-member,import-outside-toplevel
     from PIL import Image
 
-    stats = Image.core.get_stats()
+    stats = Image.core.get_stats()  # type: ignore[attr-defined]
     blocks_in_use = stats["allocated_blocks"] - stats["freed_blocks"]
     return f"{blocks_in_use * PIL_MEM_BLOCK_SIZE_IN_MIB:.1f} MiB"

--- a/fpdf/util.py
+++ b/fpdf/util.py
@@ -115,10 +115,10 @@ def get_process_rss_as_mib() -> Union[Number, None]:
     try:
         with open(f"/proc/{pid}/statm", encoding="utf8") as statm:
             return (
-                int(statm.readline().split()[1])  # type: ignore[return-value]
+                int(statm.readline().split()[1])
                 * os.sysconf("SC_PAGE_SIZE")
                 / 1024
-                / 1024
+                / 1024  # type: ignore[return-value]
             )
     except FileNotFoundError:  # /proc files only exist under Linux
         return None

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,24 @@
+[mypy]
+# TODO This errors needs to be fixed one by one
+disable_error_code = operator,  no-untyped-def, has-type, call-arg, attr-defined, arg-type, method-assign, union-attr, assignment, type-arg, misc, index, var-annotated, comparison-overlap
+
+[mypy-fontTools.*]
+ignore_missing_imports = True
+
+[mypy-endesive.*]
+ignore_missing_imports = True
+
+[mypy-defusedxml.*]
+ignore_missing_imports = True
+
+[mypy-pymemtrace.*]
+ignore_missing_imports = True
+
+[mypy-pympler.*]
+ignore_missing_imports = True
+
+[mypy-qrcode.*]
+ignore_missing_imports = True
+
+[mypy-camelot.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Part of #827

<!-- Have you done all of these things?  -->
**Checklist**:

- [ ] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [ ] A unit test is covering the code added / modified by this PR - N/A

- [X] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder - N/A

- [ ] A mention of the change is present in `CHANGELOG.md` - N/A - this not changes anything


Looks that mypy may really increase usability of this library.
Only part of functions are typed and sometimes info about type is available only in docs, so IDE cannot determine if type is valid or not.

Also this will allow to remove such strange tests - now IDE automatically shows me that this arguments aren't valid
```
def test_text_badinput():
    pdf = FPDF()
    pdf.add_page()
    pdf.set_font("Times", size=16)
    with pytest.raises(TypeError):
        pdf.text("x", 20, "Hello World")
    with pytest.raises(TypeError):
        pdf.text(20, "y", "Hello World")
    with pytest.raises(AttributeError):
        pdf.text(20, 20, 777)
    with pytest.raises(AttributeError):
        pdf.text(20, 20, (1, 2, 3))
    with pytest.raises(AttributeError):
        pdf.text(20, 20, None)
```

If someone wants to try implement more types, then I suggest to start with command
```
mypy fpdf --strict
```
and if all things are fixed, then removing one by one errors from `disable_error_code`  inside `mypy.ini` file should be enough to add types to all 

I added also `swig` into CI requirements, because without it I was not able to install all requirements.txt files.