### PR TITLE
Remove redundant calls to fonttools function

### DIFF
--- a/fpdf/fonts.py
+++ b/fpdf/fonts.py
@@ -150,7 +150,7 @@ class TTFFont:
         # fonttools cmap = unicode char to glyph name
         # saving only the keys we have a tuple with
         # the unicode characters available on the font
-        self.cmap = tuple(self.ttfont.getBestCmap().keys())
+        self.cmap = self.ttfont.getBestCmap()
 
         # saving a list of glyph ids to char to allow
         # subset by unicode (regular) and by glyph
@@ -159,7 +159,7 @@ class TTFFont:
 
         for char in self.cmap:
             # take glyph associated to char
-            glyph = self.ttfont.getBestCmap()[char]
+            glyph = self.cmap[char]
 
             # take width associated to glyph
             w = self.ttfont["hmtx"].metrics[glyph][0]
@@ -420,11 +420,11 @@ class SubsetMap:
             return Glyph(
                 self.font.glyph_ids[unicode],
                 tuple([unicode]),
-                self.font.ttfont.getBestCmap()[unicode],
+                self.font.cmap[unicode],
                 self.font.cw[unicode],
             )
         if unicode == 0x00:
-            return Glyph(self.font.cmap[0], tuple([0x00]), ".notdef", 0)
+            return Glyph(next(iter(self.font.cmap)), tuple([0x00]), ".notdef", 0)
         return None
 
     def get_glyph_by_id(self, cid) -> Glyph:


### PR DESCRIPTION
Remove redundant calls to fonttools getBestCmap to improve performance on cases like the one reported on the issue #907 


<!-- Have you done all of these things?  -->
**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [ ] A unit test is covering the code added / modified by this PR

- [ ] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [ ] A mention of the change is present in `CHANGELOG.md`

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->

<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
