### PR TITLE
Draft: Making test_cell_speed_with_long_text() faster

### DIFF
--- a/fpdf/fonts.py
+++ b/fpdf/fonts.py
@@ -399,6 +399,8 @@ class SubsetMap:
             glyph = self.get_glyph(unicode=x)
             if glyph:
                 self._char_id_per_glyph[glyph] = int(x)
+        # This is a cache to speed things up:
+        self._char_id_per_unicode = {}
 
     def __repr__(self):
         return (
@@ -414,6 +416,9 @@ class SubsetMap:
             yield glyph, char_id
 
     def pick(self, unicode: int):
+        cache_hit = self._char_id_per_unicode.get(unicode)
+        if cache_hit:
+            return cache_hit
         glyph = self.get_glyph(unicode=unicode)
         if glyph is None and unicode not in self.font.missing_glyphs:
             self.font.missing_glyphs.append(unicode)
@@ -429,6 +434,8 @@ class SubsetMap:
             char_id = self._next
             self._char_id_per_glyph[glyph] = char_id
             self._next += 1
+            # Fill cache:
+            self._char_id_per_unicode[glyph.unicode] = char_id
         return char_id
 
     def get_glyph(

--- a/fpdf/output.py
+++ b/fpdf/output.py
@@ -582,8 +582,8 @@ class OutputProducer:
                 # and then associate to the new code the glyph associated with the old code
 
                 code_to_glyph = {
-                    font.subset._map[glyph]: font.ttfont.getGlyphID(glyph.glyph_name)
-                    for glyph in font.subset._map.keys()
+                    char_id: font.ttfont.getGlyphID(glyph.glyph_name)
+                    for glyph, char_id in font.subset.items()
                 }
 
                 # 4. return the ttfile
@@ -626,7 +626,7 @@ class OutputProducer:
                         return f"{code_high:04X}{code_low:04X}"
                     return f"{unicode:04X}"
 
-                for glyph, code_mapped in font.subset._map.items():
+                for glyph, code_mapped in font.subset.items():
                     if len(glyph.unicode) == 0:
                         continue
                     bfChar.append(
@@ -955,7 +955,7 @@ def _tt_font_widths(font):
     interval = False
 
     # Glyphs sorted by mapped character id
-    glyphs = dict(sorted(font.subset._map.items(), key=lambda item: item[1]))
+    glyphs = dict(sorted(font.subset.items(), key=lambda item: item[1]))
 
     for glyph in glyphs:
         cid_mapped = glyphs[glyph]

--- a/test/fonts/test_font_internals.py
+++ b/test/fonts/test_font_internals.py
@@ -1,0 +1,8 @@
+from fpdf.fonts import Glyph
+
+
+def test_glyph_class():
+    glyph = Glyph(glyph_id=32, unicode=(0,), glyph_name=".notdef", glyph_width=0)
+    # pylint: disable=comparison-with-itself
+    assert glyph == glyph
+    assert hash(glyph) == hash(glyph)

--- a/test/text/test_cell.py
+++ b/test/text/test_cell.py
@@ -308,7 +308,7 @@ def test_cell_lasth(tmp_path):  # issue #601
     assert_pdf_equal(pdf, HERE / "cell_lasth.pdf", tmp_path)
 
 
-@ensure_exec_time_below(15)
+@ensure_exec_time_below(17)
 @ensure_rss_memory_below(mib=1)
 def test_cell_speed_with_long_text():  # issue #907
     pdf = FPDF()

--- a/test/text/test_cell.py
+++ b/test/text/test_cell.py
@@ -308,7 +308,7 @@ def test_cell_lasth(tmp_path):  # issue #601
     assert_pdf_equal(pdf, HERE / "cell_lasth.pdf", tmp_path)
 
 
-@ensure_exec_time_below(23)
+@ensure_exec_time_below(15)
 @ensure_rss_memory_below(mib=1)
 def test_cell_speed_with_long_text():  # issue #907
     pdf = FPDF()

--- a/test/text/test_cell.py
+++ b/test/text/test_cell.py
@@ -308,7 +308,7 @@ def test_cell_lasth(tmp_path):  # issue #601
     assert_pdf_equal(pdf, HERE / "cell_lasth.pdf", tmp_path)
 
 
-@ensure_exec_time_below(17)
+@ensure_exec_time_below(seconds=18)
 @ensure_rss_memory_below(mib=1)
 def test_cell_speed_with_long_text():  # issue #907
     pdf = FPDF()


### PR DESCRIPTION
This is a follow-up to #911

I made minor performance-oriented improvements to `SubsetMap`:
* in 2 places, use a single call to `dict.get(key)` instead of `key in dict` + `dict[key]`
* define our own, fast, `__hash__()` method
* add a cache (`._char_id_per_unicode`) to avoid repeated processings in `SubsetMap.pick()`

I also used this opportunity to remove all accesses to the private property `._map`
from outside the `SubsetMap` class.

_cf._ https://github.com/py-pdf/fpdf2/issues/907 for some context
