### PR TITLE
Fixing edge case when parsing a Markdown link followed by a newline - fix #916

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release is the first performed from the [@py-pdf GitHub org](https://github
 * [`FPDF.image()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.image), when provided a `BytesIO` instance, does not close it anymore - _cf._ issue [#881](https://github.com/py-pdf/fpdf2/issues/881)
 * Invalid characters were being generated when a string contains parentheses - _cf._ issue [#884](https://github.com/py-pdf/fpdf2/issues/884)
 * Frozen Glyph dataclass was causing problems for FPDFRecorder with TTF fonts - _cf._ issue [#890](https://github.com/py-pdf/fpdf2/issues/890)
+* Edge case when parsing a Markdown link followed by a newline - _cf._ issue [#916](https://github.com/py-pdf/fpdf2/issues/916)
 
 ## [2.7.5] - 2023-08-04
 ### Added

--- a/fpdf/__init__.py
+++ b/fpdf/__init__.py
@@ -1,9 +1,25 @@
+"""
+Root module.
+Gives direct access to some classes defined in submodules:
+
+* `fpdf.fpdf.FPDF`
+* `fpdf.enums.Align`
+* `fpdf.enums.TextMode`
+* `fpdf.enums.XPos`
+* `fpdf.enums.YPos`
+* `fpdf.errors.FPDFException`
+* `fpdf.fpdf.TitleStyle`
+* `fpdf.prefs.ViewerPreferences`
+* `fpdf.template.Template`
+* `fpdf.template.FlexTemplate`
+"""
+
 import sys
 
 from .enums import Align, TextMode, XPos, YPos
+from .errors import FPDFException
 from .fpdf import (
     FPDF,
-    FPDFException,
     TitleStyle,
     FPDF_FONT_DIR as _FPDF_FONT_DIR,
     FPDF_VERSION as _FPDF_VERSION,
@@ -28,25 +44,27 @@ __license__ = "LGPL 3.0"
 
 __version__ = FPDF_VERSION
 
-
 __all__ = [
-    # metadata
+    # Metadata:
     "__version__",
     "__license__",
-    # Classes
+    # Classes:
     "FPDF",
     "FPDFException",
     "Align",
+    "TextMode",
     "XPos",
     "YPos",
     "Template",
     "FlexTemplate",
-    "TextMode",
     "TitleStyle",
     "ViewerPreferences",
+    # Deprecated classes:
     "HTMLMixin",
     "HTML2FPDF",
-    # FPDF Constants
+    # FPDF constants:
     "FPDF_VERSION",
     "FPDF_FONT_DIR",
 ]
+
+__pdoc__ = {name: name.startswith("FPDF_") for name in __all__}

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -224,7 +224,7 @@ class FPDF(GraphicsStateMixin):
     MARKDOWN_BOLD_MARKER = "**"
     MARKDOWN_ITALICS_MARKER = "__"
     MARKDOWN_UNDERLINE_MARKER = "--"
-    MARKDOWN_LINK_REGEX = re.compile(r"^\[([^][]+)\]\(([^()]+)\)(.*)$")
+    MARKDOWN_LINK_REGEX = re.compile(r"^\[([^][]+)\]\(([^()]+)\)(.*)$", re.DOTALL)
     MARKDOWN_LINK_COLOR = None
     MARKDOWN_LINK_UNDERLINE = True
 


### PR DESCRIPTION
I also used this opportunity to improve the root module docstrings