### PR TITLE
delay unescaping data so as not to confuse entity names as nested tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * Previously set dash patterns were not transferred correctly to new pages.
 * Inserted Vector images used to ignore the `keep_aspect_ratio` argument.
 * [`FPDF.write_html()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.write_html) now properly honor the current text font color when styling table cells
+* [`FPDF.write_html()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.write_html) delays unescaping data so as not to confuse entity names as nested tags
 ### Changed
 * [`FPDF.table()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.table): If cell styles are provided for cells in heading rows, combine the cell style as an override with the overall heading style.
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -14,7 +14,6 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from functools import wraps
-from html import unescape
 from math import isclose
 from numbers import Number
 from os.path import splitext
@@ -393,7 +392,6 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         # Method arguments must override class & instance attributes:
         kwargs2.update(kwargs)
         html2pdf = self.HTML2FPDF_CLASS(self, *args, **kwargs2)
-        text = unescape(text)  # To deal with HTML entities
         html2pdf.feed(text)
 
     def _set_min_pdf_version(self, version):

--- a/test/html/html_table_with_data_that_contains_entity_names.pdf
+++ b/test/html/html_table_with_data_that_contains_entity_names.pdf
@@ -1,0 +1,85 @@
+%PDF-1.3
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 7 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 124
+>>
+stream
+xœ]±
+Â@ûûŠWšf½ÛËæöÀ*+ÁÅ^ˆ‚’”ÁO·õBË7Ìğ'çIŞ®5ìJŞÃèÌ±R¨jŒ¦¡·=à²$ü›ÂZ´T4¡\Ãzì®·aºW°×jüİÌ(
+Š”…diÎOÀŒÒV~D%x
+endstream
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Font <</F1 5 0 R
+/F2 6 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+8 0 obj
+<<
+/CreationDate (D:19691231190000Z19'00')
+>>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000096 00000 n 
+0000000199 00000 n 
+0000000279 00000 n 
+0000000475 00000 n 
+0000000572 00000 n 
+0000000674 00000 n 
+0000000771 00000 n 
+trailer
+<<
+/Size 9
+/Root 2 0 R
+/Info 8 0 R
+/ID [<532CEAB55CEFADFC2767C81D03D83930><532CEAB55CEFADFC2767C81D03D83930>]
+>>
+startxref
+832
+%%EOF

--- a/test/html/test_html_table.py
+++ b/test/html/test_html_table.py
@@ -330,3 +330,28 @@ def test_html_table_with_font_tags_used_to_set_text_color(tmp_path):  # issue 10
         HERE / "html_table_with_font_tags_used_to_set_text_color.pdf",
         tmp_path,
     )
+
+
+def test_html_table_with_data_that_contains_entity_names(tmp_path):  # issue 1010
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=8)
+    pdf.write_html(
+        """<table>
+    <thead>
+        <tr>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Pi &lt; 22 &divide; 7</td>
+        </tr>
+    </tbody>
+    </table>"""
+    )
+    assert_pdf_equal(
+        pdf,
+        HERE / "html_table_with_data_that_contains_entity_names.pdf",
+        tmp_path,
+    )


### PR DESCRIPTION
Fixes #1010 
False positive when attempting to detect nested html tags
Removes the unescape from write_html, data will be escaped when needed.

**Checklist**:

- [x] The GitHub pipeline is OK (green), meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [x] A unit test is covering the code added / modified by this PR

- [x] This PR is ready to be merged

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder N/A

- [x] A mention of the change is present in `CHANGELOG.md`

Had to remove the pre-commit hooks to commit as it was failing due to being on a Windows box and Python's chmod being very limited.


By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
