### PR TITLE
Update pre-commit-hooks to version 1.5.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: ^(\.[^/]*cache(__)?/.*|(.*/)?\.coverage)$
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.1
+    rev: v1.5.4
     hooks:
       - id: remove-crlf
       - id: remove-tabs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * [`FPDF.write_html()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.write_html) delays unescaping data so as not to confuse entity names as nested tags
 ### Changed
 * [`FPDF.table()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.table): If cell styles are provided for cells in heading rows, combine the cell style as an override with the overall heading style.
+* Update .pre-commit-config.yaml to pull in version 1.5.4
 
 ## [2.7.6] - 2023-10-11
 This release is the first performed from the [@py-pdf GitHub org](https://github.com/py-pdf), where `fpdf2` migrated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * [`FPDF.write_html()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.write_html) delays unescaping data so as not to confuse entity names as nested tags
 ### Changed
 * [`FPDF.table()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.table): If cell styles are provided for cells in heading rows, combine the cell style as an override with the overall heading style.
-* Update .pre-commit-config.yaml to pull in version 1.5.4
 
 ## [2.7.6] - 2023-10-11
 This release is the first performed from the [@py-pdf GitHub org](https://github.com/py-pdf), where `fpdf2` migrated.


### PR DESCRIPTION
Updates the pre-commit version in .pre-commit-config.yaml from 1.5.1 -> 1.5.4
see comment in #1018 

**Checklist**:

- [x] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [ ] A unit test is covering the code added / modified by this PR N/A

- [x] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder N/A

- [x] A mention of the change is present in `CHANGELOG.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
