### PR TITLE
Emitting warning logs for unsupported SVG tags & attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * [`FPDF.multi_cell(fill=True)`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.multi_cell) now avoids overlapping multiline strings when `padding` is non-zero.
 ### Changed
 * the public `.images`, `.icc_profiles` & `.image_filter` attributes of `FPDF` instances have been moved inside a nested `FPDF.image_cache` attribute
+* the `fpdf.svg` module now produces `WARNING` log messages for unsupported SVG tags & attributes.
+  If those logs annoy you, you can suppress them: `logging.getLogger("fpdf.svg").level = logging.ERROR`
 * [`FPDF.table()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.table): If cell styles are provided for cells in heading rows, combine the cell style as an override with the overall heading style.
 
 ## [2.7.6] - 2023-10-11

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -929,7 +929,10 @@ class SVGObject:
             elif child.tag in xmlns_lookup("svg", "image"):
                 pdf_group.add_item(self.build_image(child))
             else:
-                LOGGER.debug("Unsupported SVG tag: <%s>", child.tag)
+                LOGGER.warning(
+                    "Ignoring unsupported SVG tag: <%s> (contributions are welcome to add support for it)",
+                    child.tag,
+                )
 
         self.update_xref(group.attrib.get("id"), pdf_group)
 
@@ -980,16 +983,16 @@ class SVGObject:
         width = float(image.attrib.get("width", 0))
         height = float(image.attrib.get("height", 0))
         if "preserveAspectRatio" in image.attrib:
-            raise NotImplementedError(
-                '"preserveAspectRatio" defined on <image> is currently not supported (but contributions are welcome!)'
+            LOGGER.warning(
+                '"preserveAspectRatio" defined on <image> is currently not supported (contributions are welcome to add support for it)'
             )
         if "style" in image.attrib:
-            raise NotImplementedError(
-                '"style" defined on <image> is currently not supported (but contributions are welcome!)'
+            LOGGER.warning(
+                '"style" defined on <image> is currently not supported (contributions are welcome to add support for it)'
             )
         if "transform" in image.attrib:
-            raise NotImplementedError(
-                '"transform" defined on <image> is currently not supported (but contributions are welcome!)'
+            LOGGER.warning(
+                '"transform" defined on <image> is currently not supported (contributions are welcome to add support for it)'
             )
         # Note: at this moment, self.image_cache is not set yet:
         svg_image = SVGImage(
@@ -1037,9 +1040,10 @@ class SVGImage(NamedTuple):
 
         _, _, info = preload_image(image_cache, self.href)
         if isinstance(info, VectorImageInfo):
-            raise NotImplementedError(
-                "Inserting .svg vector graphics in <image> tags is currently not supported (but contributions are welcome!)"
+            LOGGER.warning(
+                "Inserting .svg vector graphics in <image> tags is currently not supported (contributions are welcome to add support for it)"
             )
+            return "", last_item, initial_point
         w, h = info.size_in_document_units(self.width, self.height)
         stream_content = stream_content_for_raster_image(
             info=info,


### PR DESCRIPTION
This PR is a follow-up on a comment by @gmischler in https://github.com/py-pdf/fpdf2/pull/919#discussion_r1395515588

On second-thought, I think it's best to:
* not raise an error when parsing an unsupported SVG tag or attribute, in order to allow the end user to check the resulting PDF when those markup elements are just ignored
* report more clearly those unsupported SVG tags & attributes, as WARNING logs (and not just DEBUG ones as it used to be for unsupported tags). A good thing about WARNING logs is that they get displayed to _stderr_ with the default Python logging configuration (unlike DEBUG logs or calls to `warnings.warn()`)