### PR TITLE
Tests: silencing fpdf.svg logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ### Changed
 * the public `.images`, `.icc_profiles` & `.image_filter` attributes of `FPDF` instances have been moved inside a nested `FPDF.image_cache` attribute
 * the `fpdf.svg` module now produces `WARNING` log messages for unsupported SVG tags & attributes.
-  If those logs annoy you, you can suppress them: `logging.getLogger("fpdf.svg").level = logging.ERROR`
+  If those logs annoy you, you can suppress them: `logging.getLogger("fpdf.svg").propagate = False`
 * [`FPDF.table()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.table): If cell styles are provided for cells in heading rows, combine the cell style as an override with the overall heading style.
 
 ## [2.7.6] - 2023-10-11

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,7 @@ import functools
 import gc
 import hashlib
 import linecache
+import logging
 import os
 import pathlib
 import shutil
@@ -332,6 +333,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Trace main memory allocations differences during the whole execution",
     )
+
+
+def pytest_configure():
+    "Disable some loggers."
+    logging.getLogger("fpdf.svg").propagate = False
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
This is a follow-up on a comment by @gmischler in PR #1034