### PR TITLE
Make a test independent of test infrastructure speed

### DIFF
--- a/test/image/test_load_image.py
+++ b/test/image/test_load_image.py
@@ -63,7 +63,7 @@ def test_share_images_cache(tmp_path):
 
     with time_execution() as duration:
         build_pdf_with_big_images()
-    first_time_duration =  duration.seconds
+    first_time_duration = duration.seconds
 
     with time_execution() as duration:
         build_pdf_with_big_images()

--- a/test/image/test_load_image.py
+++ b/test/image/test_load_image.py
@@ -63,8 +63,8 @@ def test_share_images_cache(tmp_path):
 
     with time_execution() as duration:
         build_pdf_with_big_images()
-    assert duration.seconds > 0.25
+    first_time_duration =  duration.seconds
 
     with time_execution() as duration:
         build_pdf_with_big_images()
-    assert duration.seconds < 0.3
+    assert duration.seconds < first_time_duration / 2


### PR DESCRIPTION
Fixes #1067

**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [ ] A unit test is covering the code added / modified by this PR N/A

- [X] This PR is ready to be merged

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder N/A

- [ ] A mention of the change is present in `CHANGELOG.md` N/A?

I don't think this change is meaningful enough to warrant addition to the contributors table

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
