### PR TITLE
New ul_bullet_color parameter for FPDF.write_html()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ## [2.7.9] - Not released yet
 ### Added
 * support for overriding paragraph direction on bidirectional text
+* new optional `ul_bullet_color` parameter for `FPDF.write_html()`
 ### Fixed
 
 ### Changed

--- a/fpdf/drawing.py
+++ b/fpdf/drawing.py
@@ -217,6 +217,11 @@ class DeviceRGB(
         """The color components as a tuple in order `(r, g, b)` with alpha omitted."""
         return self[:-1]
 
+    @property
+    def colors255(self):
+        "The color components as a tuple in order `(r, g, b)` with alpha omitted, in range 0-255."
+        return tuple(255 * v for v in self.colors)
+
     def serialize(self) -> str:
         return " ".join(number_to_str(val) for val in self.colors) + f" {self.OPERATOR}"
 
@@ -259,6 +264,11 @@ class DeviceGray(
     def colors(self):
         """The color components as a tuple in order (g,) with alpha omitted."""
         return self[:-1]
+
+    @property
+    def colors255(self):
+        "The color components as a tuple in order `(r, g, b)` with alpha omitted, in range 0-255."
+        return tuple(255 * v for v in self.colors)
 
     def serialize(self) -> str:
         return " ".join(number_to_str(val) for val in self.colors) + f" {self.OPERATOR}"

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -399,6 +399,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             dd_tag_indent (int): numeric indentation of <dd> elements
             table_line_separators (bool): enable horizontal line separators in <table>
             ul_bullet_char (str): bullet character for <ul> elements
+            ul_bullet_color (tuple | str | drawing.Device* instance): color of the <ul> bullets
             heading_sizes (dict): font size per heading level names ("h1", "h2"...)
             pre_code_font (str): font to use for <pre> & <code> blocks
             warn_on_tags_not_matching (bool): control warnings production for unmatched HTML tags

--- a/test/html/html_ul_bullet_color.pdf
+++ b/test/html/html_ul_bullet_color.pdf
@@ -1,0 +1,75 @@
+%PDF-1.3
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 6 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 158
+>>
+stream
+xœ=
+AFû=ÅWj3ÉÆ[A;aà
+Ê‚'ñ¾Îl1¸0»¦	„——|‚CÃdïf±Ú;(3â»˜GêÈø <â	äúàÖKÄû´(Pj ğ‰‚®-pFéW–Ô_×²×o0Ò`ğ‡ÌpHİa›q¨µ½ƒî$éîTÃHÖO6ü¦ø[V{v
+endstream
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Font <</F1 5 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+7 0 obj
+<<
+/CreationDate (D:19691231190000Z19'00')
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000096 00000 n 
+0000000199 00000 n 
+0000000279 00000 n 
+0000000509 00000 n 
+0000000608 00000 n 
+0000000695 00000 n 
+trailer
+<<
+/Size 8
+/Root 2 0 R
+/Info 7 0 R
+/ID [<A6A09D4A022EE77BF9506FB065F8B443><A6A09D4A022EE77BF9506FB065F8B443>]
+>>
+startxref
+756
+%%EOF

--- a/test/html/test_html.py
+++ b/test/html/test_html.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from fpdf import FPDF, HTMLMixin, TitleStyle
+from fpdf.drawing import DeviceRGB
 from fpdf.errors import FPDFException
 from test.conftest import assert_pdf_equal, LOREM_IPSUM
 
@@ -213,6 +214,25 @@ def test_html_customize_ul(tmp_path):
         pdf.write_html(html, li_tag_indent=indent, ul_bullet_char=bullet)
         pdf.ln()
     assert_pdf_equal(pdf, HERE / "html_customize_ul.pdf", tmp_path)
+
+
+def test_html_ul_bullet_color(tmp_path):
+    html = """<ul>
+        <li>item1</li>
+        <li>item2</li>
+        <li>item3</li>
+    </ul>"""
+
+    pdf = FPDF()
+    pdf.set_font_size(30)
+    pdf.add_page()
+    pdf.write_html(html, ul_bullet_color=0)  # black
+    pdf.ln()
+    pdf.write_html(html, ul_bullet_color="green")
+    pdf.ln()
+    pdf.write_html(html, ul_bullet_color=DeviceRGB(r=0.5, g=1, b=0))
+    pdf.ln()
+    assert_pdf_equal(pdf, HERE / "html_ul_bullet_color.pdf", tmp_path)
 
 
 def test_html_align_paragraph(tmp_path):


### PR DESCRIPTION
Feature requested in https://github.com/py-pdf/fpdf2/discussions/1056

**Checklist**:

- [x] The GitHub pipeline is OK (green), meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [x] A unit test is covering the code added / modified by this PR

- [x] This PR is ready to be merged

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [x] A mention of the change is present in `CHANGELOG.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
