### PR TITLE
Including code points in warning for missing glyphs in fonts

### DIFF
--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -3992,6 +3992,9 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
                 while preserving its original aspect ratio. Defaults to False.
                 Only meaningful if both `w` & `h` are provided.
 
+        If `y` is provided, this method will not trigger any page break;
+        otherwise, auto page break detection will be performed.
+
         Returns: an instance of a subclass of `ImageInfo`.
         """
         if type:

--- a/fpdf/output.py
+++ b/fpdf/output.py
@@ -550,13 +550,14 @@ class OutputProducer:
                 glyph_names = font.subset.get_all_glyph_names()
 
                 if len(font.missing_glyphs) > 0:
+                    msg = ", ".join(
+                        f"'{chr(x)}' ({chr(x).encode('unicode-escape').decode()})"
+                        for x in font.missing_glyphs[:10]
+                    )
+                    if len(font.missing_glyphs) > 10:
+                        msg += f", ... (and {len(font.missing_glyphs) - 10} others)"
                     LOGGER.warning(
-                        "Font %s is missing the following glyphs: %s",
-                        fontname,
-                        ", ".join(
-                            f"{chr(x)} ({chr(x).encode('unicode-escape').decode()})"
-                            for x in font.missing_glyphs
-                        ),
+                        "Font %s is missing the following glyphs: %s", fontname, msg
                     )
 
                 # 2. make a subset

--- a/fpdf/output.py
+++ b/fpdf/output.py
@@ -553,7 +553,10 @@ class OutputProducer:
                     LOGGER.warning(
                         "Font %s is missing the following glyphs: %s",
                         fontname,
-                        ", ".join(chr(x) for x in font.missing_glyphs),
+                        ", ".join(
+                            f"{chr(x)} ({chr(x).encode('unicode-escape').decode()})"
+                            for x in font.missing_glyphs
+                        ),
                     )
 
                 # 2. make a subset

--- a/test/fonts/test_add_font.py
+++ b/test/fonts/test_add_font.py
@@ -153,7 +153,25 @@ def test_font_missing_glyphs(caplog):
     pdf.output(devnull)
     assert (
         "Roboto is missing the following glyphs: "
-        "𝕥 (\\U0001d565), 𝕖 (\\U0001d556), 𝕤 (\\U0001d564),"
-        " 🆃 (\\U0001f183), 🅴 (\\U0001f174), 🆂 (\\U0001f182), 😲 (\\U0001f632)"
+        "'𝕥' (\\U0001d565), '𝕖' (\\U0001d556), '𝕤' (\\U0001d564), "
+        "'🆃' (\\U0001f183), '🅴' (\\U0001f174), '🆂' (\\U0001f182), '😲' (\\U0001f632)"
         in caplog.text
+    )
+
+
+def test_font_with_more_than_10_missing_glyphs(caplog):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.add_font(family="Roboto", fname=HERE / "Roboto-Regular.ttf")
+    pdf.set_font("Roboto")
+    pdf.cell(
+        text="Ogham space mark: '\U00001680' - Ideographic space: '\U00003000' - 𝒯ℰ𝒮𝒯 ⓉⒺⓈⓉ 𝕥𝕖𝕤𝕥 🆃🅴🆂🆃 🇹🇪🇸🇹"
+    )
+    pdf.output(devnull)
+    assert (
+        "Roboto is missing the following glyphs: "
+        "' ' (\\u1680), '　' (\\u3000), "
+        "'𝒯' (\\U0001d4af), 'ℰ' (\\u2130), '𝒮' (\\U0001d4ae), "
+        "'Ⓣ' (\\u24c9), 'Ⓔ' (\\u24ba), 'Ⓢ' (\\u24c8), "
+        "'𝕥' (\\U0001d565), '𝕖' (\\U0001d556), ... (and 7 others)" in caplog.text
     )

--- a/test/fonts/test_add_font.py
+++ b/test/fonts/test_add_font.py
@@ -151,4 +151,9 @@ def test_font_missing_glyphs(caplog):
     pdf.set_font("Roboto")
     pdf.cell(text="Test 𝕥𝕖𝕤𝕥 🆃🅴🆂🆃 😲")
     pdf.output(devnull)
-    assert "Roboto is missing the following glyphs: 𝕥, 𝕖, 𝕤, 🆃, 🅴, 🆂, 😲" in caplog.text
+    assert (
+        "Roboto is missing the following glyphs: "
+        "𝕥 (\\U0001d565), 𝕖 (\\U0001d556), 𝕤 (\\U0001d564),"
+        " 🆃 (\\U0001f183), 🅴 (\\U0001f174), 🆂 (\\U0001f182), 😲 (\\U0001f632)"
+        in caplog.text
+    )

--- a/test/fonts/test_font_fallback.py
+++ b/test/fonts/test_font_fallback.py
@@ -198,4 +198,7 @@ def test_glyph_not_on_any_font(caplog):
     pdf.set_fallback_fonts(["DejaVuSans"])
     pdf.cell(text="Test 𝕥𝕖𝕤𝕥 🆃🅴🆂🆃 😲")
     pdf.output(devnull)
-    assert "Roboto is missing the following glyphs: 🆃, 🅴, 🆂" in caplog.text
+    assert (
+        "Roboto is missing the following glyphs: 🆃 (\\U0001f183), 🅴 (\\U0001f174), 🆂 (\\U0001f182)"
+        in caplog.text
+    )

--- a/test/fonts/test_font_fallback.py
+++ b/test/fonts/test_font_fallback.py
@@ -199,6 +199,6 @@ def test_glyph_not_on_any_font(caplog):
     pdf.cell(text="Test 𝕥𝕖𝕤𝕥 🆃🅴🆂🆃 😲")
     pdf.output(devnull)
     assert (
-        "Roboto is missing the following glyphs: 🆃 (\\U0001f183), 🅴 (\\U0001f174), 🆂 (\\U0001f182)"
-        in caplog.text
+        "Roboto is missing the following glyphs: "
+        "'🆃' (\\U0001f183), '🅴' (\\U0001f174), '🆂' (\\U0001f182)" in caplog.text
     )


### PR DESCRIPTION
Implementing suggestion from https://github.com/py-pdf/fpdf2/issues/1171#issuecomment-2126845201.
Also slightly improving a docstring as mentioned there: https://github.com/py-pdf/fpdf2/issues/1156#issuecomment-2095444563

**Checklist**:

- [x] The GitHub pipeline is OK (green), meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [x] A unit test is covering the code added / modified by this PR

- [x] This PR is ready to be merged

- [x] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [NA] A mention of the change is present in `CHANGELOG.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
