### PR TITLE
Doc: mention that text() does lack features (#1265)

### DIFF
--- a/docs/Text.md
+++ b/docs/Text.md
@@ -4,13 +4,13 @@ There are several ways in fpdf to add text to a PDF document, each of which come
 
 ## Simple Text Methods
 
-| method | lines | markdown support | HTML support | accepts new current position | details                                                                                                                                                         |
-| -- | :--: | :--: | :--: | :--: |-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`.text()`](#text)  | one | no | no | fixed | Inserts a single-line text string with a precise location on the base line of the font.                                                                         |
-| [`.cell()`](#cell)  | one | yes | no | yes | Inserts a single-line text string within the boundaries of a given box, optionally with background and border.                                                  |
-| [`.multi_cell()`](#multi_cell) | several | yes | no | yes | Inserts a multi-line text string within the boundaries of a given box, optionally with background, border and padding.                                          |
-| [`.write()`](#write) | several | no | no | auto | Inserts a multi-line text string within the boundaries of the page margins, starting at the current x/y location (typically the end of the last inserted text). |
-| [`.write_html()`](#write_html) | several | no | yes | auto | An extension to `.write()`, with additional parsing of basic HTML tags.                                                                                         
+| method | lines | markdown support | HTML support | text shaping | accepts new current position | details                                                                                                                                                         |
+| -- | :--: | :--: | :--: | :--: | :--: |-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`.text()`](#text)  | one | no | no | no | fixed | Inserts a single-line text string with a precise location on the base line of the font.                                                                         |
+| [`.cell()`](#cell)  | one | yes | no | yes | yes | Inserts a single-line text string within the boundaries of a given box, optionally with background and border.                                                  |
+| [`.multi_cell()`](#multi_cell) | several | yes | no | yes | yes | Inserts a multi-line text string within the boundaries of a given box, optionally with background, border and padding.                                          |
+| [`.write()`](#write) | several | no | no | yes | auto | Inserts a multi-line text string within the boundaries of the page margins, starting at the current x/y location (typically the end of the last inserted text). |
+| [`.write_html()`](#write_html) | several | no | yes | yes | auto | An extension to `.write()`, with additional parsing of basic HTML tags.
 
 ## Flowable Text Regions
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -353,7 +353,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         permissions=AccessPermission.all(),
         encrypt_metadata=False,
     ):
-        """ "
+        """
         Activate encryption of the document content.
 
         Args:
@@ -2551,6 +2551,12 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             y (float): ordinate of the origin
             text (str): string to print
             txt (str): [**DEPRECATED since v2.7.6**] string to print
+
+        Notes
+        -----
+
+        `text()` lacks many of the features available in `FPDF.write()`,
+        `FPDF.cell()` and `FPDF.multi_cell()` like markdown and text shaping.
         """
         if not self.font_family:
             raise FPDFException("No font set, you need to call set_font() beforehand")


### PR DESCRIPTION
* adept comparison table in Text.md (add text shaping)
* add a note in the functions doc string

Fixes #1265 

**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] The GitHub pipeline is OK (green), <!-- The maintainers will trigger it if this is your 1st contribution -->
      meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [ ] A unit test is covering the code added / modified by this PR N/A

- [x] This PR is ready to be merged

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder  N/A

- [ ] A mention of the change is present in `CHANGELOG.md`  N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
