### PR TITLE
[CI fixup] Extending test_intense_image_rendering() unit test test max memory usage

### DIFF
--- a/test/test_perfs.py
+++ b/test/test_perfs.py
@@ -8,7 +8,7 @@ HERE = Path(__file__).resolve().parent
 
 
 @ensure_exec_time_below(seconds=9)
-@ensure_rss_memory_below(mib=8)
+@ensure_rss_memory_below(mib=15)
 def test_intense_image_rendering():
     png_file_paths = []
     for png_file_path in (HERE / "image/png_images/").glob("*.png"):


### PR DESCRIPTION
We seem to have hit the memory usage of 8MiB set on `test_intense_image_rendering()` for several weeks now:
![image](https://github.com/user-attachments/assets/f006588b-55f3-49e3-b922-9ed3e84f0ada)

It does not seem possible to me that this change of behaviour could be linked to a recent change in `fpdf2` code.

I noticed that this test failed when the CI pipeline switched from using **Python 3.12.5 to using 3.12.6**.
I could not find any mention of changes impacting memory in Python 3.12.6 release notes though:
https://www.python.org/downloads/release/python-3126/

Anyway, this PR increases the memory limit of this unit test from 8MiB to 15MiB.

**Checklist**:

- [x] The GitHub pipeline is OK (green), meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.

- [x] A unit test is covering the code added / modified by this PR

- [x] This PR is ready to be merged

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [ ] A mention of the change is present in `CHANGELOG.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
