### PR TITLE
Adopting grype security scan

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -39,6 +39,12 @@ jobs:
           pylint fpdf test tutorial/tuto*.py
           bandit -c .banditrc.yml -r contributors/ fpdf/ tutorial/
           semgrep scan --config auto --error --strict --exclude-rule=python.lang.security.insecure-hash-function.insecure-hash-function fpdf
+      - name: Scan current project
+        if: matrix.python-version == '3.12' && matrix.platform == 'ubuntu-latest'
+        uses: anchore/scan-action@v3
+        with:
+          path: "."
+          fail-build: true
       - name: Ensure code has been autoformatted with black 🖌️
         if: matrix.python-version == '3.12' && matrix.platform == 'ubuntu-latest'
         run: black --check .

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 [![build status](https://github.com/py-pdf/fpdf2/workflows/build/badge.svg)](https://github.com/py-pdf/fpdf2/actions?query=branch%3Amaster)
 [![codecov](https://codecov.io/gh/py-pdf/fpdf2/branch/master/graph/badge.svg)](https://codecov.io/gh/py-pdf/fpdf2)
-![security: bandit, pylint, semgrep](https://img.shields.io/badge/linters-bandit,pylint,semgrep-yellow.svg)
+![Pypi Trusted Publisher: enabled](https://img.shields.io/badge/Pypi%20Trusted%20Publisher-enabled-green.svg)
+![checks: bandit, pylint, semgrep](https://img.shields.io/badge/checks-bandit,pylint,semgrep,grype-green.svg)
 
 [![Dependents](https://img.shields.io/librariesio/dependents/pypi/fpdf2)](https://libraries.io/pypi/fpdf2/dependents)
 [![Downloads per month](https://pepy.tech/badge/fpdf2/month)](https://pepy.tech/project/fpdf2)

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -218,8 +218,7 @@ Also (optionnal, once every year), update `contributors/contributors-map-small.p
 5. check that [the GitHub Actions succeed](https://github.com/py-pdf/fpdf2/actions), and that [a new release appears on Pypi](https://pypi.org/project/fpdf2/#history)
 6. perform a [GitHub release](https://github.com/py-pdf/fpdf2/releases), taking the description from the `CHANGELOG.md`.
 It will create a new `git` tag.
-7. Announce the release on [r/pythonnews](https://www.reddit.com/r/pythonnews/),
-   and add an announcement to the documentation website: [docs/overrides/main.html](https://github.com/py-pdf/fpdf2/blob/master/docs/overrides/main.html)
+7. Announce the release on [r/pythonnews](https://www.reddit.com/r/pythonnews/)
 
 ## Documentation
 The standalone documentation is in the `docs` subfolder,


### PR DESCRIPTION
Adopting https://github.com/anchore/grype vulnerability scanner

Current output from the CI pipeline execution:
```
Run anchore/scan-action@v3
/usr/bin/chmod +x /home/runner/work/_temp/0deb6c07-bb84-4737-9ac1-9e50389b3681
/home/runner/work/_temp/0deb6c07-bb84-4737-9ac1-9e50389b3681 -b /home/runner/work/_temp/0deb6c07-bb84-4737-9ac1-9e50389b3681_grype v0.74.4
[info] checking github for release tag='v0.74.4' 
[info] fetching release script for tag='v0.74.4' 
[info] checking github for release tag='v0.74.4' 
[info] using release tag='v0.74.4' version='0.74.4' os='linux' arch='amd64' 
[info] installed /home/runner/work/_temp/0deb6c07-bb84-4737-9ac1-9e50389b3681_grype/grype 
grype output...
  Executing: grype -o sarif --fail-on medium dir:.
```