### PR TITLE
Fix the HTML table with null text in span cells that don't show correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * support for LZWDecode compression [issue #1271](https://github.com/py-pdf/fpdf2/issues/1271)
 ### Fixed
 * `FPDF.set_text_shaping(False)` was broken since version 2.7.8 and is now working properly - [issue #1287](https://github.com/py-pdf/fpdf2/issues/1287)
+* fixed bug where cells with `rowspan`, `colspan` > 1 and null text were not displayed properly - [issue #1293](https://github.com/py-pdf/fpdf2/issues/1293)
 
 ## [2.8.1] - 2024-10-04
 ### Added

--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -1088,7 +1088,11 @@ class HTML2FPDF(HTMLParser):
                     self.td_th.get("bgcolor", self.tr.get("bgcolor", None))
                 )
                 style = FontFace(fill_color=bgcolor) if bgcolor else None
-                self.table_row.cell(text="", style=style)
+                colspan = int(self.td_th.get("colspan", "1"))
+                rowspan = int(self.td_th.get("rowspan", "1"))
+                self.table_row.cell(
+                    text="", style=style, colspan=colspan, rowspan=rowspan
+                )
             self.td_th = None
         if tag == "font":
             if self.style_stack:

--- a/test/html/html_table_with_null_text_in_span_cell.pdf
+++ b/test/html/html_table_with_null_text_in_span_cell.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 6 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 174
+>>
+stream
+xœ};Â0{Ÿâ•Ğ,ë]Ûk·HPĞ!|J×‡(…R?ifôÇO·­Øì=¼3ê»êîN2i„e!ğV(*Ô“0NNØ(gX1*Óî#¥a3Å3™Gf!P/X›¶…¬QoC³QàE„&	?cÅGåß
+Ë‰â¾+CÅ7"NıU)‘h,ÄiNı¾h0î®˜6îè{\'
+endstream
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Font <</F1 5 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+7 0 obj
+<<
+/CreationDate (D:19691231190000Z19'00')
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000096 00000 n 
+0000000199 00000 n 
+0000000279 00000 n 
+0000000525 00000 n 
+0000000624 00000 n 
+0000000711 00000 n 
+trailer
+<<
+/Size 8
+/Root 2 0 R
+/Info 7 0 R
+/ID [<89E5665BE80C1471D9EC67EB53E96BFD><89E5665BE80C1471D9EC67EB53E96BFD>]
+>>
+startxref
+772
+%%EOF

--- a/test/html/test_html_table.py
+++ b/test/html/test_html_table.py
@@ -373,3 +373,32 @@ def test_html_table_honoring_align(tmp_path):
         </table>"""
     )
     assert_pdf_equal(pdf, HERE / "html_table_honoring_align.pdf", tmp_path)
+
+
+def test_html_table_with_null_text_in_span_cell(tmp_path):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.write_html(
+        """<table border="1">
+        <tr>
+            <td rowspan=2></td>
+            <td>cell 2</td>
+            <td>cell 3</td>
+        </tr>
+        <tr>
+            <td>cell 4</td>
+            <td>cell 5</td>
+        </tr>
+        <tr>
+            <td colspan=2></td>
+            <td>cell 7</td>
+        </tr>
+    </table>
+        """,
+        table_line_separators=True,
+    )
+    assert_pdf_equal(
+        pdf,
+        HERE / "html_table_with_null_text_in_span_cell.pdf",
+        tmp_path,
+    )


### PR DESCRIPTION
Fixes #1293

This Pr to fix HTML table with `td` tag have `rowspan`, `colspan` > 1 and text inside is null the pdf output not show table correctly

**Checklist**:

- [x] A unit test is covering the code added / modified by this PR

- [ ] This PR is ready to be merged

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [ ] A mention of the change is present in `CHANGELOG.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
