### PR TITLE
Switching to VeraPDF 1.27.96

### DIFF
--- a/scripts/install-verapdf.sh
+++ b/scripts/install-verapdf.sh
@@ -6,25 +6,20 @@
 
 set -o pipefail -o errexit -o nounset -o xtrace
 
+VERSION=1.27.96
+PUB_KEY_FINGERPRINT=13DD102B4DD69354D12DE5A83184863278B17FE7
+FILENAME=verapdf-greenfield-${VERSION}-installer.zip
+ZIP_URL=https://software.verapdf.org/dev/${VERSION%.*}/${FILENAME}
+
 rm -rf verapdf-*
-wget --quiet https://software.verapdf.org/dev/1.27/verapdf-greenfield-1.27.96-installer.zip
+wget --quiet ${ZIP_URL}
+wget --quiet ${ZIP_URL}.asc
+gpg --keyserver keyserver.ubuntu.com --recv ${PUB_KEY_FINGERPRINT}
+gpg --verify ${FILENAME}.asc
 unzip verapdf*installer.zip
-(
-    # Press 1 to continue, 2 to quit, 3 to redisplay:
-    echo 1
-    # Select the installation path:
-    echo $PWD/verapdf
-    # Enter O for OK, C to Cancel:
-    echo O
-    # Press 1 to continue, 2 to quit, 3 to redisplay:
-    echo 1
-    # Include optional pack 'veraPDF Corpus and Validation model' - Enter Y for Yes, N for No:
-    echo N
-    # Include optional pack 'veraPDF Documentation' - Enter Y for Yes, N for No:
-    echo N
-    # Include optional pack 'veraPDF Sample Plugins' - Enter Y for Yes, N for No:
-    echo N
-    # Press 1 to continue, 2 to quit, 3 to redisplay:
-    echo 1
-) | verapdf-*/verapdf-install
+# Path to verapdf.properties must be relative to verapdf-*/ :
+verapdf-*/verapdf-install -options ../scripts/verapdf.properties
+# verapdf.properties targets an installation in /tmp, because an absolute path is required :
+mv /tmp/verapdf .
+verapdf/verapdf --version
 rm -rf verapdf-*

--- a/scripts/install-verapdf.sh
+++ b/scripts/install-verapdf.sh
@@ -7,7 +7,7 @@
 set -o pipefail -o errexit -o nounset -o xtrace
 
 rm -rf verapdf-*
-wget --quiet https://software.verapdf.org/rel/1.22/verapdf-greenfield-1.22.3-installer.zip
+wget --quiet https://software.verapdf.org/dev/1.27/verapdf-greenfield-1.27.96-installer.zip
 unzip verapdf*installer.zip
 (
     # Press 1 to continue, 2 to quit, 3 to redisplay:

--- a/scripts/verapdf.properties
+++ b/scripts/verapdf.properties
@@ -1,0 +1,1 @@
+INSTALL_PATH=/tmp/verapdf

--- a/test/test_perfs.py
+++ b/test/test_perfs.py
@@ -13,7 +13,7 @@ PNG_FILE_PATHS.extend(
 )
 
 
-@ensure_exec_time_below(seconds=9)
+@ensure_exec_time_below(seconds=10)
 @ensure_rss_memory_below(mib=15)
 def test_intense_image_rendering(tmp_path):
     pdf = FPDF()


### PR DESCRIPTION
* switch from VeraPDF v1.22.3 to v1.27.96
* add GPG signature verification on the VeraPDF ZIP archive downloaded
* increased the execution time threshold in `test_perfs.py` from 9s to 10s

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
