### PR TITLE
Fixing test_intense_image_rendering() in CI pipeline

### DIFF
--- a/test/test_perfs.py
+++ b/test/test_perfs.py
@@ -14,7 +14,7 @@ PNG_FILE_PATHS.extend(
 
 
 @ensure_exec_time_below(seconds=10)
-@ensure_rss_memory_below(mib=15)
+@ensure_rss_memory_below(mib=30)  # VERY dependent on the environement
 def test_intense_image_rendering(tmp_path):
     pdf = FPDF()
     for _ in range(2000):


### PR DESCRIPTION
This test has been broken for a week:
![image](https://github.com/user-attachments/assets/46d61f7e-7090-450d-93f2-7ccd4e125682)

I initially tried to solve this in PR https://github.com/py-pdf/fpdf2/pull/1318 by increasing the execution time threshold in `test_perfs.py` from 9s to 10s, but then this other error appeared:
```
FAILED test/test_perfs.py::test_intense_image_rendering - assert (291.9765625 - 267.390625) < 15
```

The annoying thing is that I do not quite understand why the RAM usage increased from 15MiB to 25MiB...

* last OK execution: https://github.com/py-pdf/fpdf2/actions/runs/11953462734/job/33321379801
* next KO execution: https://github.com/py-pdf/fpdf2/actions/runs/12074007599/job/33671208678

What differs?

Dependencies: `uharfbuzz` went from version `0.42.0` to `0.43.0`.
And the GitHub Actions runner image went from `20241117.1.0` to `20241124.1.0`

I tested going back to `uharfbuzz==0.42.0` and it made no difference.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
