### PR TITLE
Support for ~~strikethrough~~ with markdown=True

### DIFF
--- a/docs/CombineWithMarkdown.md
+++ b/docs/CombineWithMarkdown.md
@@ -1,7 +1,7 @@
 # Combine with Markdown
 Several `fpdf2` methods allow Markdown syntax elements:
 
-* [`FPDF.cell()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.cell) has an optional `markdown=True` parameter that makes it possible to use `**bold**`, `__italics__` or `--underlined--` Markdown markers
+* [`FPDF.cell()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.cell) has an optional `markdown=True` parameter that makes it possible to use `**bold**`, `__italics__`, `~~strikethrough~~` or `--underlined--` Markdown markers
 * [`FPDF.multi_cell()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.multi_cell) & [`FPDF.table()`](Tables.md) methods have a similar feature
 
 But `fpdf2` also allows for basic conversion **from HTML to PDF** (_cf._ [HTML](HTML.md)).

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -224,6 +224,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
 
     MARKDOWN_BOLD_MARKER = "**"
     MARKDOWN_ITALICS_MARKER = "__"
+    MARKDOWN_STRIKETHROUGH_MARKER = "~~"
     MARKDOWN_UNDERLINE_MARKER = "--"
     MARKDOWN_ESCAPE_CHARACTER = "\\"
     MARKDOWN_LINK_REGEX = re.compile(r"^\[([^][]+)\]\(([^()]+)\)(.*)$", re.DOTALL)
@@ -3590,10 +3591,11 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
 
             yield Fragment(text, self._get_current_graphics_state(), self.k)
             return
-        txt_frag, in_bold, in_italics, in_underline = (
+        txt_frag, in_bold, in_italics, in_strikethrough, in_underline = (
             [],
             "B" in self.font_style,
             "I" in self.font_style,
+            bool(self.strikethrough),
             bool(self.underline),
         )
         current_fallback_font = None
@@ -3605,6 +3607,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             gstate["font_style"] = ("B" if in_bold else "") + (
                 "I" if in_italics else ""
             )
+            gstate["strikethrough"] = in_strikethrough
             gstate["underline"] = in_underline
             if current_fallback_font:
                 gstate["font_family"] = "".join(
@@ -3634,6 +3637,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             is_marker = text[:2] in (
                 self.MARKDOWN_BOLD_MARKER,
                 self.MARKDOWN_ITALICS_MARKER,
+                self.MARKDOWN_STRIKETHROUGH_MARKER,
                 self.MARKDOWN_UNDERLINE_MARKER,
             )
             half_marker = text[0]
@@ -3655,6 +3659,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
                     gstate["font_style"] = ("B" if in_bold else "") + (
                         "I" if in_italics else ""
                     )
+                    gstate["strikethrough"] = in_strikethrough
                     gstate["underline"] = in_underline
                     yield TotalPagesSubstitutionFragment(
                         self.str_alias_nb_pages,
@@ -3683,6 +3688,8 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
                             in_bold = not in_bold
                         if text[:2] == self.MARKDOWN_ITALICS_MARKER:
                             in_italics = not in_italics
+                        if text[:2] == self.MARKDOWN_STRIKETHROUGH_MARKER:
+                            in_strikethrough = not in_strikethrough
                         if text[:2] == self.MARKDOWN_UNDERLINE_MARKER:
                             in_underline = not in_underline
                         text = text[2:]

--- a/test/text/multi_cell_markdown_strikethrough.pdf
+++ b/test/text/multi_cell_markdown_strikethrough.pdf
@@ -1,0 +1,73 @@
+%PDF-1.3
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 6 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 96
+>>
+stream
+xœ5Ì»@@FáŞSü%…1³Ø¥•P¨çÜ’µâõ…D{òåôSépG"ë¹!fè„Vß”IW9ªè€ø~İÇ°øãš—ºı¤._"ÉZ¤B–áG|Ÿ»	
+endstream
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Font <</F1 5 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+7 0 obj
+<<
+/CreationDate (D:19691231190000Z)
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000096 00000 n 
+0000000199 00000 n 
+0000000279 00000 n 
+0000000446 00000 n 
+0000000545 00000 n 
+0000000632 00000 n 
+trailer
+<<
+/Size 8
+/Root 2 0 R
+/Info 7 0 R
+/ID [<80D56A41F481AC67A7206823F5CA62D1><80D56A41F481AC67A7206823F5CA62D1>]
+>>
+startxref
+687
+%%EOF

--- a/test/text/test_markdown_parse.py
+++ b/test/text/test_markdown_parse.py
@@ -8,6 +8,8 @@ GSTATE_B = GSTATE.copy()
 GSTATE_B["font_style"] = "B"
 GSTATE_I = GSTATE.copy()
 GSTATE_I["font_style"] = "I"
+GSTATE_S = GSTATE.copy()
+GSTATE_S["strikethrough"] = True
 GSTATE_U = GSTATE.copy()
 GSTATE_U["underline"] = True
 GSTATE_BI = GSTATE.copy()
@@ -15,11 +17,17 @@ GSTATE_BI["font_style"] = "BI"
 
 
 def test_markdown_parse_simple_ok():
-    frags = tuple(FPDF()._parse_chars("**bold**, __italics__ and --underlined--", True))
+    frags = tuple(
+        FPDF()._parse_chars(
+            "**bold**, __italics__, ~~strikethrough~~ and --underlined--", True
+        )
+    )
     expected = (
         Fragment("bold", GSTATE_B, k=PDF.k),
         Fragment(", ", GSTATE, k=PDF.k),
         Fragment("italics", GSTATE_I, k=PDF.k),
+        Fragment(", ", GSTATE, k=PDF.k),
+        Fragment("strikethrough", GSTATE_S, k=PDF.k),
         Fragment(" and ", GSTATE, k=PDF.k),
         Fragment("underlined", GSTATE_U, k=PDF.k),
     )

--- a/test/text/test_multi_cell_markdown.py
+++ b/test/text/test_multi_cell_markdown.py
@@ -25,6 +25,14 @@ def test_multi_cell_markdown(tmp_path):
     assert_pdf_equal(pdf, HERE / "multi_cell_markdown.pdf", tmp_path)
 
 
+def test_multi_cell_markdown_strikethrough(tmp_path):
+    pdf = fpdf.FPDF()
+    pdf.add_page()
+    pdf.set_font("Times", size=32)
+    pdf.multi_cell(w=pdf.epw, text="~~strikethrough~~", markdown=True)
+    assert_pdf_equal(pdf, HERE / "multi_cell_markdown_strikethrough.pdf", tmp_path)
+
+
 def test_multi_cell_markdown_escaped(tmp_path):
     pdf = fpdf.FPDF()
     pdf.add_page()


### PR DESCRIPTION
Follow-up of PR https://github.com/py-pdf/fpdf2/pull/1340

**Checklist**:
- [x] A unit test is covering the code added / modified by this PR

- [x] This PR is ready to be merged

- [x] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [x] A mention of the change is present in `CHANGELOG.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
