### PR TITLE
Fix: do not insert bottom padding in cells produced by multi_cell() when a page break occurs in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ### Fixed
 * [`FPDF.write_html()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.write_html): Fixed rendering of content following `<a>` tags; now correctly resets emphasis style post `</a>` tag: hyperlink styling contained within the tag authority. - [Issue #1311](https://github.com/py-pdf/fpdf2/issues/1311)
 * [FPDF.footer()](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.footer) does not "leak" its text style to the [table of contents](https://py-pdf.github.io/fpdf2/DocumentOutlineAndTableOfContents.html#table-of-contents) anymore
+* do not insert bottom padding in cells produced by [`FPDF.multi_cell()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.multi_cell) when a page break occurs in them - [issue #1395](https://github.com/py-pdf/fpdf2/issues/1395)
 
 ## [2.8.2] - 2024-12-16
 ### Added

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -4146,7 +4146,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         page_break_triggered = False
 
         for text_line_index, text_line in enumerate(text_lines):
-            if self._perform_page_break_if_need_be(h + padding.bottom):
+            if self._perform_page_break_if_need_be(h):
                 page_break_triggered = True
                 self.y += padding.top
 

--- a/test/text/multi_cell_with_padding_and_page_break.pdf
+++ b/test/text/multi_cell_with_padding_and_page_break.pdf
@@ -1,0 +1,103 @@
+%PDF-1.3
+1 0 obj
+<<
+/Count 2
+/Kids [3 0 R
+5 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 8 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 365
+>>
+stream
+xœÍÙ½JA…á>WñÙ)È:ßßÌN+ÄJao@PQ‰¨DÈíb‘`eğ…­fŠ9œ…§9&—³2d“Õìt’“¹ŠÚPŠL÷r>ÍŞd}è:è(cñ¡‡L·R†±§L+9¼¸[,^åıáq)ëïF–7Ï¯‹;¹:›üÕİ‘LOë(rı=LëºãC´Ï0{x{{·;Bë_}Ô›{xûçİî,µm³èĞšm²ìëüÚI&§“pF'®œN´3:)ÓIí‰è¤Îé¤)£“ä[ƒalu±ÕÆVå›alc³1ŒÍÊ16“al:ÇØ4†±©c³0ŒÎ16ÃØ¨c#ÆFpŒgÊ16
+ÃXïc}dëc¬'ÃX±îcİ8Æº2ŒµÎ1ÖF†±Ö8ÆZekÉ1Öœa¬ÇXS†±V8Æjg« ÍK!›—‚6/…l^
+Ú¼²y)hó‚L^ Å2xı÷Şõ¶¸ 
+endstream
+endobj
+5 0 obj
+<<
+/Contents 6 0 R
+/Parent 1 0 R
+/Resources 9 0 R
+/Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Filter /FlateDecode
+/Length 220
+>>
+stream
+xœÍ”AjAE÷sŠŸ]étMOUMoÅHÈ*¾À€•	*¼¾C0Äå„ümÿE=Í«ñZÅ S5+xZ¤1¢|à¹TI‚´hc
+¹AYB‚{rÂãæˆÇîsß¯ğ6_<¼¬ú~7Å×zFØ&(Ûï¿9<Ë…#óæ›ãnßn÷Y<s81çq¢Êá¤I<N’p8‘Ìã$:…ËJãÄZÆšó4Ö”£±Öğ4ÖGc­æi¬	Gc5ó4V[Æªó4V£±ªÿÜØ+Iúù±£‰¸\©Î»$«2
+endstream
+endobj
+7 0 obj
+<<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+8 0 obj
+<<
+/Font <</F1 7 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+9 0 obj
+<<
+/Font <</F1 7 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+10 0 obj
+<<
+/CreationDate (D:19691231190000Z)
+>>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000009 00000 n 
+0000000102 00000 n 
+0000000205 00000 n 
+0000000285 00000 n 
+0000000722 00000 n 
+0000000802 00000 n 
+0000001094 00000 n 
+0000001191 00000 n 
+0000001278 00000 n 
+0000001365 00000 n 
+trailer
+<<
+/Size 11
+/Root 2 0 R
+/Info 10 0 R
+/ID [<25FE795748189A57C5CC0E1D097DA231><25FE795748189A57C5CC0E1D097DA231>]
+>>
+startxref
+1421
+%%EOF

--- a/test/text/test_multi_cell.py
+++ b/test/text/test_multi_cell.py
@@ -545,6 +545,16 @@ def test_multi_cell_with_padding_check_input():
         pdf.multi_cell(0, 5, LONG_TEXT, border=1, padding=(5, 5, 5, 5, 5, 5))
 
 
+def test_multi_cell_with_padding_and_page_break(tmp_path):  # issue #1395
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica")
+    pdf.multi_cell(
+        w=0, text="Hello, this is a sample PDF!" * 300, padding=[0, 0, 50, 0]
+    )
+    assert_pdf_equal(pdf, HERE / "multi_cell_with_padding_and_page_break.pdf", tmp_path)
+
+
 def test_multi_cell_return_value(tmp_path):
     pdf = FPDF()
     pdf.add_page()


### PR DESCRIPTION
_cf._ #1395

**Checklist**:

- [x] A unit test is covering the code added / modified by this PR

- [x] This PR is ready to be merged

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [x] A mention of the change is present in `CHANGELOG.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
