### PR TITLE
Fix: Update Polish tutorial source

### DIFF
--- a/tutorial/notebook.ipynb
+++ b/tutorial/notebook.ipynb
@@ -123,7 +123,7 @@
     "- [Ελληνικά](https://py-pdf.github.io/fpdf2/Tutorial-gr.html)\n",
     "- [עברית](https://py-pdf.github.io/fpdf2/Tutorial-he.html)\n",
     "- [Dutch](https://py-pdf.github.io/fpdf2/Tutorial-nl.html)\n",
-    "- [Polski]((https://py-pdf.github.io/fpdf2/Tutorial-pl.html))\n",
+    "- [Polski]((https://py-pdf.github.io/fpdf2/Tutorial-pl.html)\n",
     "- [Türkçe](https://py-pdf.github.io/fpdf2/Tutorial-tr.html)\n",
     "- [Indonesian](https://py-pdf.github.io/fpdf2/Tutorial-id.html)"
    ]


### PR DESCRIPTION
# PR Summary
This small PR fixes the Polish tutorial reference in `tutorial/notebook.ipynb`. Relevant page: https://py-pdf.github.io/fpdf2/notebook.html