### PR TITLE
Actions: Force python 3.13.3 for windows on the test matrix

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -107,7 +107,7 @@ jobs:
         id: set-python-version
         run: |
           if [ "${{ matrix.platform }}" = "windows-latest" ] && [ "${{ matrix.python-version }}" = "3.13" ]; then
-            echo "version=3.13t" >> "$GITHUB_OUTPUT"
+            echo "version=3.13.4" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ matrix.python-version }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -94,7 +94,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13t']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         platform: [ubuntu-22.04, windows-latest]
     runs-on: ${{ matrix.platform }}
     permissions: {}
@@ -103,17 +103,26 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - name: Set effective Python version
+        id: set-python-version
+        run: |
+          if [ "${{ matrix.platform }}" = "windows-latest" ] && [ "${{ matrix.python-version }}" = "3.13" ]; then
+            echo "version=3.13t" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ matrix.python-version }}" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
       - name: Set up Python ${{ matrix.python-version }} 🔧
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ steps.set-python-version.outputs.version }}
       - name: Install system dependencies ⚙️
         if: ${{ startsWith(matrix.platform, 'ubuntu') }}
         # Ghostscript is needed for test/table/test_table_extraction.py
         run: sudo apt-get update --allow-releaseinfo-change && sudo apt-get install ghostscript
       - name: Install qpdf ⚙️
         # We run the unit tests WITHOUT qpdf for a single parallel execution / Python version:
-        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version != '3.13t' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version != '3.13' }}
         run: sudo apt-get update --allow-releaseinfo-change && sudo apt-get install qpdf
       - name: Install Python dependencies ⚙️
         run: |
@@ -122,7 +131,7 @@ jobs:
       - name: Run tests ☑
         env:
           CHECK_EXEC_TIME: ${{ matrix.python-version == '3.9' && 'test-enabled' || '' }}
-          CHECK_RSS_MEMORY: ${{ matrix.python-version == '3.13t' && 'test-enabled' || '' }}
+          CHECK_RSS_MEMORY: ${{ matrix.python-version == '3.13' && 'test-enabled' || '' }}
         run: |
           # Ensuring there is no `generate=True` left remaining in calls to assert_pdf_equal:
           grep -IRF generate=True test/ && exit 1
@@ -130,7 +139,7 @@ jobs:
           pytest -vv --trace-memory-usage
       - name: Upload coverage report to codecov.io ☑
         # We only upload coverage ONCE, for a single parallel execution / Python version:
-        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.13t' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.13' }}
         run: bash <(curl -s https://codecov.io/bash)
       - name: Run tests with the minimal versions of fpdf2 direct dependencies ☑
         if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.8' }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -107,7 +107,7 @@ jobs:
         id: set-python-version
         run: |
           if [ "${{ matrix.platform }}" = "windows-latest" ] && [ "${{ matrix.python-version }}" = "3.13" ]; then
-            echo "version=3.13.4" >> "$GITHUB_OUTPUT"
+            echo "version=3.13.3" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ matrix.python-version }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -94,7 +94,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13t']
         platform: [ubuntu-22.04, windows-latest]
     runs-on: ${{ matrix.platform }}
     permissions: {}
@@ -113,7 +113,7 @@ jobs:
         run: sudo apt-get update --allow-releaseinfo-change && sudo apt-get install ghostscript
       - name: Install qpdf ⚙️
         # We run the unit tests WITHOUT qpdf for a single parallel execution / Python version:
-        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version != '3.13' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version != '3.13t' }}
         run: sudo apt-get update --allow-releaseinfo-change && sudo apt-get install qpdf
       - name: Install Python dependencies ⚙️
         run: |
@@ -122,7 +122,7 @@ jobs:
       - name: Run tests ☑
         env:
           CHECK_EXEC_TIME: ${{ matrix.python-version == '3.9' && 'test-enabled' || '' }}
-          CHECK_RSS_MEMORY: ${{ matrix.python-version == '3.13' && 'test-enabled' || '' }}
+          CHECK_RSS_MEMORY: ${{ matrix.python-version == '3.13t' && 'test-enabled' || '' }}
         run: |
           # Ensuring there is no `generate=True` left remaining in calls to assert_pdf_equal:
           grep -IRF generate=True test/ && exit 1
@@ -130,7 +130,7 @@ jobs:
           pytest -vv --trace-memory-usage
       - name: Upload coverage report to codecov.io ☑
         # We only upload coverage ONCE, for a single parallel execution / Python version:
-        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.13' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.13t' }}
         run: bash <(curl -s https://codecov.io/bash)
       - name: Run tests with the minimal versions of fpdf2 direct dependencies ☑
         if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.8' }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Some guidelines are provided like this, in HTML comments, to expedite the code review before merging your contribution.

First, please make sure that you have read the documentation page on fpdf2 development:
https://py-pdf.github.io/fpdf2/Development.html

If you're new to contributing to open source projects,
you might find this free video course helpful: http://kcd.im/pull-request
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

The workflow is failing because pykcs11 (endesive dependency) is failing on windows python 3.13.3+
This change will freeze the python 3.13.3 version for windows on the workflow.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] A unit test is covering the code added / modified by this PR

- [ ] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [ ] A mention of the change is present in `CHANGELOG.md`

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->

<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
