### PR TITLE
add set_bottom_margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ## [2.8.4] - Not released yet
 ### Added
 * documentation on [internal linking with variable page numbers](https://py-pdf.github.io/fpdf2/Links.html#internal-links)
+* [`set_bottom_margin()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.set_bottom_margin)
+
 ### Fixed
 * [`FPDF.write_html()`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.write_html): Fixed custom styling of `<p>` & tables - [issue #1453](https://github.com/py-pdf/fpdf2/issues/1453)
 * an `IndexError` was raised in some cases when rendering HTML with nested lists - _cf._ [issue #1358](https://github.com/py-pdf/fpdf2/issues/1358)

--- a/docs/Margins.md
+++ b/docs/Margins.md
@@ -18,5 +18,6 @@ Several methods can be used to set margins:
 * [set_left_margin](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.FPDF.set_left_margin)
 * [set_right_margin](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.FPDF.set_right_margin)
 * [set_top_margin](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.FPDF.set_top_margin)
+* [set_bottom_margin](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.FPDF.set_top_margin)
 * [set_margins](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.FPDF.set_margins)
 * [set_auto_page_break](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.FPDF.set_auto_page_break)

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -602,6 +602,15 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         """
         self.r_margin = margin
 
+    def set_bottom_margin(self, margin):
+        """
+        Sets the document bottom margin.
+
+        Args:
+            margin (float): margin in the unit specified to FPDF constructor
+        """
+        self.b_margin = margin
+
     def set_auto_page_break(self, auto, margin=0):
         """
         Set auto page break mode and triggering bottom margin.


### PR DESCRIPTION
This PR adds `set_bottom_margin` as a method on `FPDF` for completeness alongside `set_top_margin`, `set_left_margin` and `set_right_margin`.

As this method is a simple setter for a thoroughly tested attribute, I don't feel like any tests are necessary here.