### PR TITLE
Improve pack_codes_into_bytes() performance by using NumPy as an optional dependency

### DIFF
--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -614,6 +614,13 @@ def pack_codes_into_bytes(codes):
     bits_in_buffer = 0
     output = bytearray()
 
+    try:
+        import numpy as np
+    except ImportError:
+        pass
+    else:
+        # Replace with a numpy array
+        codes = np.array(codes, dtype=np.uint32)
     for code in codes:
         buffer = (buffer << bits_per_code) | code
         bits_in_buffer += bits_per_code


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Fixes #1380.

- If NumPy is available, replace python list with a NumPy array.
- If NumPy is available, this change reduces the execution time of the test_insert_jpg_lzwdecode test case from ~41s to ~0.65s.


<!-- Have you done all of these things?  -->
**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] A unit test is covering the code added / modified by this PR

- [ ] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [ ] A mention of the change is present in `CHANGELOG.md`

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->

<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
