### PR TITLE
Create utility function to compare file path on tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -53,6 +53,15 @@ LOREM_IPSUM = (
 )
 
 
+def assert_same_file(file1, file2):
+    """
+    Assert that two files are the same, by comparing their absolute paths.
+    """
+    assert os.path.normcase(os.path.abspath(file1)) == os.path.normcase(
+        os.path.abspath(file2)
+    )
+
+
 def assert_pdf_equal(
     actual,
     expected,

--- a/test/errors/test_FPDF_errors.py
+++ b/test/errors/test_FPDF_errors.py
@@ -6,6 +6,8 @@ from fpdf.errors import FPDFException, FPDFUnicodeEncodingException
 from fpdf.image_parsing import get_img_info
 from PIL import Image
 
+from test.conftest import assert_same_file
+
 HERE = Path(__file__).resolve().parent
 
 
@@ -82,7 +84,7 @@ def test_doc_option_only_core_fonts_encoding():
         assert str(e.value) == msg
 
     for r in record:
-        assert r.filename == __file__
+        assert_same_file(r.filename, __file__)
 
 
 def test_adding_content_after_closing():

--- a/test/fonts/test_add_font.py
+++ b/test/fonts/test_add_font.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from fpdf import FPDF
-from test.conftest import assert_pdf_equal
+from test.conftest import assert_pdf_equal, assert_same_file
 
 HERE = Path(__file__).resolve().parent
 
@@ -33,22 +33,22 @@ def test_deprecation_warning_for_FPDF_CACHE_DIR_and_FPDF_CACHE_MODE():
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_DIR
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_DIR = "/tmp"
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_MODE
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_MODE = 1
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     fpdf.SOME = 1
     assert fpdf.SOME == 1
@@ -58,22 +58,22 @@ def test_deprecation_warning_for_FPDF_CACHE_DIR_and_FPDF_CACHE_MODE():
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_DIR
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_DIR = "/tmp"
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_MODE
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     with pytest.warns(DeprecationWarning) as record:
         fpdf.FPDF_CACHE_MODE = 1
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     fpdf.SOME = 1
     assert fpdf.SOME == 1
@@ -92,7 +92,7 @@ def test_add_font_with_str_fname_ok(tmp_path):
 
         for r in record:
             if r.category == DeprecationWarning:
-                assert r.filename == __file__
+                assert_same_file(r.filename, __file__)
 
 
 def test_add_core_fonts():
@@ -109,7 +109,7 @@ def test_add_core_fonts():
         assert not pdf.fonts  # No fonts added, as all of them are core fonts
 
     for r in record:
-        assert r.filename == __file__
+        assert_same_file(r.filename, __file__)
 
 
 def test_render_en_dash(tmp_path):  # issue-166

--- a/test/fonts/test_set_font.py
+++ b/test/fonts/test_set_font.py
@@ -6,7 +6,7 @@ import pytest
 from fpdf import FPDF
 from fpdf.errors import FPDFException
 from fpdf.fonts import CORE_FONTS, CORE_FONTS_CHARWIDTHS
-from test.conftest import assert_pdf_equal
+from test.conftest import assert_pdf_equal, assert_same_file
 
 HERE = Path(__file__).resolve().parent
 
@@ -84,7 +84,7 @@ def test_set_font_aliases_as_font():
             pdf.set_font(alias)
 
         assert len(record) == 1
-        assert record[0].filename == __file__
+        assert_same_file(record[0].filename, __file__)
 
         # Test if font family is set correctly
         assert pdf.font_family == alternative
@@ -172,7 +172,7 @@ def test_set_font_zapfdingbats_symbol_with_style():
                     assert pdf.font_style == ""
 
                 assert len(record) == 1
-                assert record[0].filename == __file__
+                assert_same_file(record[0].filename, __file__)
 
                 # Test if underline is set correctly
                 assert pdf.underline == int("U" in style)

--- a/test/html/test_html.py
+++ b/test/html/test_html.py
@@ -6,7 +6,7 @@ import pytest
 from fpdf import FPDF, FontFace, HTMLMixin, TextStyle, TitleStyle
 from fpdf.drawing import DeviceRGB
 from fpdf.errors import FPDFException
-from test.conftest import assert_pdf_equal, LOREM_IPSUM
+from test.conftest import assert_pdf_equal, LOREM_IPSUM, assert_same_file
 
 
 HERE = Path(__file__).resolve().parent
@@ -486,7 +486,7 @@ def test_html_HTMLMixin_deprecation_warning(tmp_path):
         assert_pdf_equal(pdf, HERE / "html_description.pdf", tmp_path)
 
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
 
 def test_html_whitespace_handling(tmp_path):  # Issue 547

--- a/test/shapes/test_polyline.py
+++ b/test/shapes/test_polyline.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import fpdf
 from fpdf.errors import FPDFException
-from test.conftest import assert_pdf_equal
+from test.conftest import assert_pdf_equal, assert_same_file
 
 import pytest
 
@@ -35,7 +35,7 @@ def test_polyline_command_all_k(unit, factor):
         data.clear()
 
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     pdf.polyline(scale_points(POLYLINE_COORDINATES, factor), polygon=True)
     assert "".join(data) == "10.00 831.89 m40.00 831.89 l10.00 801.89 l h S"

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -3,6 +3,8 @@ from filecmp import cmp
 import fpdf
 import pytest
 
+from test.conftest import assert_same_file
+
 
 def test_repeated_calls_to_output(tmp_path):
     pdf = fpdf.FPDF()
@@ -16,7 +18,7 @@ def test_deprecation_warning(tmp_path):
     with pytest.warns(DeprecationWarning) as record:
         pdf.output(tmp_path / "empty.pdf", "F")
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
 
 def test_save_to_absolute_path(tmp_path):

--- a/test/text/test_cell.py
+++ b/test/text/test_cell.py
@@ -6,6 +6,7 @@ import pytest
 from fpdf import FPDF, FPDFException
 from test.conftest import (
     assert_pdf_equal,
+    assert_same_file,
     ensure_exec_time_below,
     ensure_rss_memory_below,
     LOREM_IPSUM,
@@ -71,7 +72,7 @@ def test_cell_ln_1(tmp_path):
     with pytest.warns(DeprecationWarning) as record:
         doc.cell(w=100, h=LINE_HEIGHT, border=1, text="Lorem ipsum", ln=1)
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
     doc.cell(w=100, h=LINE_HEIGHT, border=1, text="Ut nostrud irure")
     assert_pdf_equal(doc, HERE / "ln_1.pdf", tmp_path)

--- a/test/text/test_multi_cell.py
+++ b/test/text/test_multi_cell.py
@@ -5,7 +5,7 @@ import pytest
 from fpdf import FPDF, FPDFException
 from fpdf.enums import MethodReturnValue, YPos
 
-from test.conftest import assert_pdf_equal, LOREM_IPSUM
+from test.conftest import assert_pdf_equal, LOREM_IPSUM, assert_same_file
 
 
 HERE = Path(__file__).resolve().parent
@@ -293,7 +293,7 @@ def test_multi_cell_split_only():  # discussion 314
             pdf.multi_cell(w=0, h=LINE_HEIGHT, text=text, split_only=True) == expected
         )
     assert len(record) == 1
-    assert record[0].filename == __file__
+    assert_same_file(record[0].filename, __file__)
 
 
 def test_multi_cell_with_empty_contents(tmp_path):  # issue 349

--- a/test/text/test_render_styled.py
+++ b/test/text/test_render_styled.py
@@ -6,7 +6,7 @@ import pytest
 import fpdf
 from fpdf.enums import Align, XPos, YPos
 from fpdf.line_break import MultiLineBreak, TextLine
-from test.conftest import assert_pdf_equal
+from test.conftest import assert_pdf_equal, assert_same_file
 
 HERE = Path(__file__).resolve().parent
 
@@ -502,7 +502,7 @@ def test_cell_lnpos(tmp_path):
             )
 
         assert len(record) == 1
-        assert record[0].filename == __file__
+        assert_same_file(record[0].filename, __file__)
 
         # mark the new position in the file with crosshairs for verification
         with doc.rotation(i * -15, doc.x, doc.y):
@@ -545,7 +545,7 @@ def test_multi_cell_ln_newpos(tmp_path):
                 ln=ln,
             )
         assert len(record) == 1
-        assert record[0].filename == __file__
+        assert_same_file(record[0].filename, __file__)
 
         # mark the new position in the file with crosshairs for verification
         with doc.rotation(i * -15, doc.x, doc.y):

--- a/test/text/test_unbreakable.py
+++ b/test/text/test_unbreakable.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from fpdf import FPDF, FPDFException
-from test.conftest import assert_pdf_equal
+from test.conftest import assert_pdf_equal, assert_same_file
 
 import pytest
 
@@ -134,7 +134,7 @@ def test_multi_cell_table_unbreakable_with_split_only(tmp_path):  # issue 359
 
             for r in record:
                 if r.category == DeprecationWarning:
-                    assert r.filename == __file__
+                    assert_same_file(r.filename, __file__)
 
             no_of_lines_in_cell = len(result)
             if no_of_lines_in_cell > max_no_of_lines_in_cell:
@@ -225,7 +225,7 @@ def test_multi_cell_table_unbreakable_with_split_only(tmp_path):  # issue 359
 
     for r in record:
         if r.category == DeprecationWarning:
-            assert r.filename == __file__
+            assert_same_file(r.filename, __file__)
 
     assert_pdf_equal(
         pdf, HERE / "multi_cell_table_unbreakable_with_split_only.pdf", tmp_path


### PR DESCRIPTION
Create a utility function to compare file path - solve a problem where in some scenarios we can have false test fails on windows because of file case

```
                    if r.category == DeprecationWarning:
>                       assert r.filename == __file__
E                       AssertionError: assert 'c:\\Apps\\fp...nbreakable.py' == 'C:\\apps\\fp...nbreakable.py'
E
E                         - C:\apps\fpdf2\test\text\test_unbreakable.py
E                         ? ^  ^
E                         + c:\Apps\fpdf2\test\text\test_unbreakable.py
E                         ? ^  ^
```