### PR TITLE
SVG: Recurse into <a> tags to render nested elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * `multi_cell()` text clipping bug - [issue #1471](https://github.com/py-pdf/fpdf2/issues/1471)
 * HTML lists bullets are now properly displayed when using unicode fonts - _cf._ [issue #1496](https://github.com/py-pdf/fpdf2/issues/1496)
 * clarified documentation in [Maths.md](https://py-pdf.github.io/fpdf2/Maths.html) regarding DataFrame string conversion for PDF rendering
+* children of `<a>` tags in SVGs are now correctly rendered - _cf._ [PR #1522](https://github.com/py-pdf/fpdf2/pull/1522)
 
 ### Changed
 * [`accept_page_break`](https://py-pdf.github.io/fpdf2/fpdf/fpdf.html#fpdf.fpdf.FPDF.accept_page_break) is now only called once per page break - _cf._ [issue #1489](https://github.com/py-pdf/fpdf2/issues/1489)

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -850,6 +850,13 @@ class SVGObject:
         for child in defs:
             if child.tag in xmlns_lookup("svg", "g"):
                 self.build_group(child)
+            elif child.tag in xmlns_lookup("svg", "a"):
+                # <a> tags aren't supported but we need to recurse into them to
+                # render nested elements.
+                LOGGER.warning(
+                    "Ignoring unsupported SVG tag: <a> (contributions are welcome to add support for it)",
+                )
+                self.build_group(child)
             elif child.tag in xmlns_lookup("svg", "path"):
                 self.build_path(child)
             elif child.tag in xmlns_lookup("svg", "image"):
@@ -919,6 +926,13 @@ class SVGObject:
             if child.tag in xmlns_lookup("svg", "defs"):
                 self.handle_defs(child)
             elif child.tag in xmlns_lookup("svg", "g"):
+                pdf_group.add_item(self.build_group(child), False)
+            elif child.tag in xmlns_lookup("svg", "a"):
+                # <a> tags aren't supported but we need to recurse into them to
+                # render nested elements.
+                LOGGER.warning(
+                    "Ignoring unsupported SVG tag: <a> (contributions are welcome to add support for it)",
+                )
                 pdf_group.add_item(self.build_group(child), False)
             elif child.tag in xmlns_lookup("svg", "path"):
                 pdf_group.add_item(self.build_path(child), False)

--- a/test/svg/generated_pdf/simple_rect_in_a_tag.pdf
+++ b/test/svg/generated_pdf/simple_rect_in_a_tag.pdf
@@ -1,0 +1,82 @@
+%PDF-1.4
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 100.00 100.00]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Group <</Type /Group /S /Transparency /CS /DeviceRGB>>
+/Parent 1 0 R
+/Resources 8 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 107
+>>
+stream
+xœ5M1@@ìïóìçh5JQ!W)Pø¾Ý»Èlv&;3Y‹ÁPî<^sA‚L‰‰°(úÙ"<XV¹íø#i'ŸÔ¿¢Y5Gû ¼ôÖ	ÕÜÖJÖ;L}ìžòA§!T>ÐaL0ãK
+endstream
+endobj
+5 0 obj
+<< /Type /ExtGState
+/LC 0 >>
+endobj
+6 0 obj
+<< /Type /ExtGState
+/LW 2 >>
+endobj
+7 0 obj
+<< /Type /ExtGState
+/LW 0.567 >>
+endobj
+8 0 obj
+<<
+/ExtGState <</GS0 5 0 R
+/GS1 6 0 R
+/GS2 7 0 R>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+9 0 obj
+<<
+/CreationDate (D:19691231190000Z)
+>>
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000096 00000 n 
+0000000199 00000 n 
+0000000335 00000 n 
+0000000514 00000 n 
+0000000558 00000 n 
+0000000602 00000 n 
+0000000650 00000 n 
+0000000765 00000 n 
+trailer
+<<
+/Size 10
+/Root 2 0 R
+/Info 9 0 R
+/ID [<B622728FD426F4674D11A4F9BC11E004><B622728FD426F4674D11A4F9BC11E004>]
+>>
+startxref
+820
+%%EOF

--- a/test/svg/svg_sources/simple_rect_in_a_tag.svg
+++ b/test/svg/svg_sources/simple_rect_in_a_tag.svg
@@ -1,0 +1,6 @@
+<svg viewbox="0 0 100 60" xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <a href="http://example.com">
+    <rect width="80"  height="40" x="10" y="10"
+        fill="red" style="fill: yellow; stroke: cadetblue; stroke-width: 2;"  />
+  </a>
+</svg>

--- a/test/svg/test_svg.py
+++ b/test/svg/test_svg.py
@@ -280,6 +280,20 @@ class TestSVGObject:
 
         assert_pdf_equal(pdf, GENERATED_PDF_DIR / f"{svg_file.stem}.pdf", tmp_path)
 
+    def test_svg_render_content_in_a_tag(self, tmp_path):
+        svg_file = parameters.svgfile("simple_rect_in_a_tag.svg")
+
+        svg = fpdf.svg.SVGObject.from_file(svg_file)
+
+        pdf = fpdf.FPDF(unit="pt", format=(svg.width, svg.height))
+        pdf.set_margin(0)
+        pdf.allow_images_transparency = False
+        pdf.add_page()
+
+        svg.draw_to_page(pdf)
+
+        assert_pdf_equal(pdf, GENERATED_PDF_DIR / f"{svg_file.stem}.pdf", tmp_path)
+
     def test_svg_rendering_image_over_page_break(self, tmp_path):
         pdf = fpdf.FPDF()
         pdf.add_page()


### PR DESCRIPTION
At the moment we just skip <a> tags because we don't support linking. However, <a> tags can contain graphics elements that need to be rendered.

The full list of container-like elements can be found at
   https://svgwg.org/svg2-draft/struct.html#GroupsOverview

> An element which can have graphics elements and other container elements as
> child elements. Specifically: ‘a’, ‘clipPath’, ‘defs’, ‘g’, ‘marker’, ‘mask’,
> ‘pattern’, ‘svg’, ‘switch’ and ‘symbol’.

I'm trying to render SVGs from [lilypond](https://lilypond.org/), before/after this change:

<img width="262" height="62" alt="Screenshot 2025-08-11 at 07 54 16" src="https://github.com/user-attachments/assets/81e2f0b8-e11b-42f3-9f40-14d42ca8d3a3" />
<img width="262" height="62" alt="Screenshot 2025-08-11 at 07 53 25" src="https://github.com/user-attachments/assets/9a4119ad-c6ab-4e1a-8a75-f67182aeaec8" />

**Checklist**:

- [x] A unit test is covering the code added / modified by this PR

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder (N/A)
 
- [x] A mention of the change is present in `CHANGELOG.md`

- [x] This PR is ready to be merged

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
