### PR TITLE
Prevent merging fragments of different types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ### Fixed
 * preserving font table `fvar` to keep compatibility with variable fonts - _cf._ [issue #1528](https://github.com/py-pdf/fpdf2/issues/1528)
 * issue with markdown when fallback fonts containing non-alphanumeric characters are used - _cf._ [issue #1535](https://github.com/py-pdf/fpdf2/issues/1535)
+* a bug with merging fragments of different types
 
 ## [2.8.4] - 2025-08-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ### Fixed
 * preserving font table `fvar` to keep compatibility with variable fonts - _cf._ [issue #1528](https://github.com/py-pdf/fpdf2/issues/1528)
 * issue with markdown when fallback fonts containing non-alphanumeric characters are used - _cf._ [issue #1535](https://github.com/py-pdf/fpdf2/issues/1535)
-* a bug with merging fragments of different types
+* a bug with merging fragments of different types - _cf._ PR [#1567](https://github.com/py-pdf/fpdf2/pull/1567)
 
 ## [2.8.4] - 2025-08-11
 ### Added

--- a/fpdf/line_break.py
+++ b/fpdf/line_break.py
@@ -246,7 +246,7 @@ class Fragment:
         return (
             self.graphics_state == other.graphics_state
             and self.k == other.k
-            and isinstance(other, self.__class__)
+            and self.__class__ == other.__class__
         )
 
     def get_character_width(self, character: str, print_sh=False, initial_cs=True):

--- a/test/text/test_line_break.py
+++ b/test/text/test_line_break.py
@@ -1,5 +1,11 @@
 from fpdf import FPDF, FPDFException, TextMode
-from fpdf.line_break import Fragment, MultiLineBreak, CurrentLine, TextLine
+from fpdf.line_break import (
+    Fragment,
+    MultiLineBreak,
+    CurrentLine,
+    TextLine,
+    TotalPagesSubstitutionFragment,
+)
 from fpdf.enums import Align, CharVPos
 
 import pytest
@@ -19,6 +25,10 @@ class FxFragment(Fragment):
         """Return the relevant width from "wdict"."""
         cw = self.wdict[self.font_style]
         return cw[character]
+
+
+class FxTotalPagesSubstitutionFragment(FxFragment, TotalPagesSubstitutionFragment):
+    pass
 
 
 class FxFont:
@@ -1428,3 +1438,47 @@ def test_line_break_no_initial_newline():  # issue-847
     multi_line_break = MultiLineBreak(fragments, 188, [0, 0])
     text_line = multi_line_break.get_line()
     assert text_line.fragments
+
+
+def test_substitution_fragments_are_not_merged_with_base_fragments():
+    """
+    There are three fragments, all of which fit on a single line. Normally, they would be merged into one fragment.
+    However, a substitution fragment cannot be merged with a base fragment, otherwise,
+    characters from the base fragment would be lost after replacement.
+
+    Expected behavior:
+        The fragments are not merged.
+    """
+    pdf = FPDF()
+    assert pdf.str_alias_nb_pages
+    alias = pdf.str_alias_nb_pages
+
+    char_width = 6
+    line_width = 200 * char_width
+    text_before = "before"
+    text_after = "after"
+
+    alphabet = {
+        "normal": {},
+    }
+    for char in text_before + alias + text_after:
+        alphabet["normal"][char] = char_width
+
+    graphics_state = gs_with_font(_gs_normal, alphabet["normal"])
+
+    fragment_before = FxFragment(text_before, graphics_state, 1, None, alphabet)
+    fragment_after = FxFragment(text_after, graphics_state, 1, None, alphabet)
+    substitution_fragment = FxTotalPagesSubstitutionFragment(
+        alias, graphics_state, 1, None, alphabet
+    )
+
+    multi_line_break = MultiLineBreak(
+        [fragment_before, substitution_fragment, fragment_after],
+        line_width,
+        [0, 0],
+    )
+
+    line = multi_line_break.get_line()
+    assert line.fragments == [fragment_before, substitution_fragment, fragment_after]
+
+    assert multi_line_break.get_line() is None


### PR DESCRIPTION
An instance of `SubstitutionFragment` is also an instance of `Fragment`. With certain orderings, a substitution fragment could be extended with characters from another fragment. When the substitution fragment is later replaced with a value, all of those characters are lost.

For example, before the fix, the string `f'There are {{nb}} pages'` was rendered as `There are 20`.

Two consecutive substitution fragments will still be merged. Since there is only one substitution fragment, you'll see one value in the result file.

**Checklist**:

- [x] A unit test is covering the code added / modified by this PR

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder (N/A)

- [x] A mention of the change is present in `CHANGELOG.md`

- [x] This PR is ready to be merged

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
