### PR TITLE
Add clone() example to README.md

### DIFF
--- a/docs/overrides/README.md
+++ b/docs/overrides/README.md
@@ -1,1 +1,22 @@
 _cf._ https://squidfunk.github.io/mkdocs-material/customization/#overriding-blocks
+## Example: Using `clone()`
+
+You can duplicate an existing object using the `clone()` method.  
+This is useful to reuse the same element multiple times without redefining it.
+
+```python
+from fpdf import FPDF
+
+# Create a PDF instance
+pdf = FPDF()
+pdf.add_page()
+pdf.set_font("Arial", size=16)
+
+# Original cell
+pdf.cell(40, 10, "Original Cell")
+
+# Clone the cell and place it below
+cloned = pdf.clone(pdf.cell(40, 10, "Cloned Cell"))
+
+# Save the PDF
+pdf.output("clone_example.pdf")


### PR DESCRIPTION
Added a practical example of using clone() in docs/overrides/README.md. Helps developers understand how to use clone() in practice.
This PR adds a practical example of using the clone() function to docs/overrides/README.md.
- Shows how to duplicate an existing object using clone().
- Preserves existing content and formatting.
By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
