### PR TITLE
Dropping support for Python 3.9

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -94,7 +94,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     permissions: {}
@@ -121,7 +121,7 @@ jobs:
           pip install --upgrade . -r test/requirements.txt
       - name: Run tests ☑
         env:
-          CHECK_EXEC_TIME: ${{ matrix.python-version == '3.9' && 'test-enabled' || '' }}
+          CHECK_EXEC_TIME: ${{ matrix.python-version == '3.10' && 'test-enabled' || '' }}
           CHECK_RSS_MEMORY: ${{ matrix.python-version == '3.13' && 'test-enabled' || '' }}
         run: |
           # Ensuring there is no `generate=True` left remaining in calls to assert_pdf_equal:
@@ -133,7 +133,7 @@ jobs:
         if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.13' }}
         run: bash <(curl -s https://codecov.io/bash)
       - name: Run tests with the minimal versions of fpdf2 direct dependencies ☑
-        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.9' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu') && matrix.python-version == '3.10' }}
         run: |
           # Ensuring that those minimal versions remain compatible:
           sed -i '/install_requires/,/\n/s/>=/==/' setup.cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,18 +25,20 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * support for dashed lines in FlexTemplate elements - _cf._ [issue #1503](https://github.com/py-pdf/fpdf2/issues/1503)
 * support for rendering color font glyphs in different formats (SBIX, CBDT/CBLC, SVG, COLRv0 and COLRv1) - _cf._ [PR #1305](https://github.com/py-pdf/fpdf2/pull/1305)
 * support for linking to named destinations - _cf._ [issue #1545](https://github.com/py-pdf/fpdf2/issues/1545) - thanks to @RamBelitkar: [link to documentation](https://py-pdf.github.io/fpdf2/NamedDestinations.html)
-* native support for PDF/A compliance verification - including PDF/A-1B, 2B, 2U, 3B, 3U, 4, 4E and 4F: [link to documentation](https://py-pdf.github.io/fpdf2/pdfa.html) Accessible PDF/A documents (PDF/A 1A, 2A and 3A) are not yet supported.
+* native support for PDF/A compliance verification - including PDF/A-1B, 2B, 2U, 3B, 3U, 4, 4E and 4F: [link to documentation](https://py-pdf.github.io/fpdf2/pdfa.html). Accessible PDF/A documents (PDF/A 1A, 2A and 3A) are not yet supported.
 * `unicode_range` parameter for `add_font()` to restrict which Unicode characters a font covers, similar to CSS `@font-face` unicode-range. This allows users to control font priority on a per-character-range basis and prevents unwanted glyphs from main fonts when better alternatives exist in fallback fonts. Supports multiple input formats: CSS-style strings (`"U+1F600-1F64F, U+2600-26FF"`), lists of strings, tuples, integers, and mixed formats - _cf._ [issue #1586](https://github.com/py-pdf/fpdf2/issues/1586)
-* Utility function `get_parsed_unicode_range()` to convert various unicode*range formats to codepoints - \_cf.* [issue #1586](https://github.com/py-pdf/fpdf2/issues/1586)
+* Utility function [`get_parsed_unicode_range()`](https://py-pdf.github.io/fpdf2/fpdf/util.html#fpdf.util.get_parsed_unicode_range) to convert various unicode range formats to codepoints - _cf._ [issue #1586](https://github.com/py-pdf/fpdf2/issues/1586)
 * `variations` parameter added in `add_font()` to allow the use of variable fonts - _cf._ [issue #1544](https://github.com/py-pdf/fpdf2/issues/1544): [link to documentation](https://py-pdf.github.io/fpdf2/Unicode.html#variable-fonts)
 
 ### Fixed
 * preserving font table `fvar` to keep compatibility with variable fonts - _cf._ [issue #1528](https://github.com/py-pdf/fpdf2/issues/1528)
-* issue with markdown when fallback fonts containing non-alphanumeric characters are used - _cf._ [issue #1535](https://github.com/py-pdf/fpdf2/issues/1535)
+* issue with Markdown when fallback fonts containing non-alphanumeric characters are used - _cf._ [issue #1535](https://github.com/py-pdf/fpdf2/issues/1535)
 * a bug with merging fragments of different types - _cf._ PR [#1567](https://github.com/py-pdf/fpdf2/pull/1567)
 * updated destination page numbers of internal links when the ToC renderer spans multiple pages - _cf._ PR [#1566](https://github.com/py-pdf/fpdf2/pull/1566)
-* GoTo action and add test for GoTo a named destination - _cf._ [issue #1545](https://github.com/py-pdf/fpdf2/issues/1545)
+* GoTo action and add test for GoTo named destinations - _cf._ [issue #1545](https://github.com/py-pdf/fpdf2/issues/1545)
 * TableOfContents class missing cell clearance on spacing calculation - _cf._ [issue #1582](https://github.com/py-pdf/fpdf2/issues/1582)
+### Removed
+* support for Python 3.9, that reached [end-of-life](https://devguide.python.org/versions/#supported-versions) in October 2025
 
 ## [2.8.4] - 2025-08-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install git+https://github.com/py-pdf/fpdf2.git@master
 
 ## Features
 
- * Python 3.9+ support
+ * Python 3.10+ support
  * [Unicode](https://py-pdf.github.io/fpdf2/Unicode.html) (UTF-8) TrueType font subset embedding
  * Internal / external [links](https://py-pdf.github.io/fpdf2/Links.html)
  * Embedding images, including transparency and alpha channel

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -83,7 +83,7 @@ You can run a single test by executing: `pytest -k function_name`.
 Alternatively, you can use [Tox](https://tox.readthedocs.io/en/latest/).
 It is self-documented in the `tox.ini` file in the repository.
 To run tests for all versions of Python, simply run `tox`.
-If you do not want to run tests for all versions of python, run `tox -e py39`
+If you do not want to run tests for all versions of python, run `tox -e py313`
 (or your version of Python).
 
 ### Why is a test failing?

--- a/docs/HTML.md
+++ b/docs/HTML.md
@@ -78,7 +78,7 @@ pdf.write_html("""
 pdf.output("html.pdf")
 ```
 
-Internally `FPDF.write_html()` uses the [`fpdf.html.HTML2PDF` class](https://py-pdf.github.io/fpdf2/fpdf/html.html#fpdf.html.HTML2PDF) that implements HTML parsing using [`html.parser.HTMLParser`](https://docs.python.org/3/library/html.parser.html).
+Internally `FPDF.write_html()` uses the [`fpdf.html.HTML2FPDF` class](https://py-pdf.github.io/fpdf2/fpdf/html.html#fpdf.html.HTML2FPDF) that implements HTML parsing using [`html.parser.HTMLParser`](https://docs.python.org/3/library/html.parser.html).
 
 ### Styling HTML tags globally
 

--- a/docs/History.md
+++ b/docs/History.md
@@ -42,7 +42,7 @@ The notable exceptions are:
 * [Template](https://py-pdf.github.io/fpdf2/fpdf/template.html#fpdf.template.Template) elements now have a **transparent background** by default, instead of white
 
 Additionally, HTML rendering is not guaranteed to be identical regarding whitespace,
-especially since version 2.7.6 and the new set of classes introduced to manage text flow: <https://py-pdf.github.io/fpdf2/TextRegion.html>
+especially since version 2.7.6 and the new set of classes introduced to manage text flow: [Text Flow Regions](TextRegion.md)
 
 Some features are also **deprecated**.
 As of version 2.8.4 they **still work** but **generate a warning** when used:

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Go try it **now** online in a Jupyter notebook: [![Open In Colab](https://colab.
 ## Main features ##
 
 * Easy to use, with a user-friendly [API](https://py-pdf.github.io/fpdf2/fpdf/), and easy to extend
-* Python 3.9+ support
+* Python 3.10+ support
 * [Unicode](Unicode.md) (UTF-8) TrueType font subset embedding (Central European, Cyrillic, Greek, Baltic, Thai, Chinese, Japanese, Korean, Hindi and almost any other language in the world)
 * Internal / external [links](Links.md)
 * Embedding images, including transparency and alpha channel, using [Pillow (Python Imaging Library)](https://pillow.readthedocs.io/en/stable/)

--- a/fpdf/util.py
+++ b/fpdf/util.py
@@ -162,6 +162,7 @@ def get_parsed_unicode_range(unicode_range):
     Parse unicode_range parameter into a set of codepoints.
 
     Supports CSS-style formats:
+
     - String with comma-separated ranges: "U+1F600-1F64F, U+2600-26FF, U+2615"
     - List of strings: ["U+1F600-1F64F", "U+2600", "U+26FF"]
     - List of tuples: [(0x1F600, 0x1F64F), (0x2600, 0x26FF)]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
   Intended Audience :: Developers
   License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
   Programming Language :: Python
-  Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
@@ -38,10 +37,10 @@ keywords =
 [options]
 packages =
   fpdf
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
   defusedxml
-  Pillow>=8.0.0,!=9.2.*  # minimum version tested there: https://github.com/py-pdf/fpdf2/actions/runs/2295868575
+  Pillow>=8.3.2,!=9.2.*  # minimum version tested there: https://github.com/py-pdf/fpdf2/actions/runs/2295868575
   # Version 9.2.0 is excluded due to DoS vulnerability with TIFF images: https://github.com/py-pdf/fpdf2/issues/628
   # Version exclusion explained here: https://devpress.csdn.net/python/630462c0c67703293080c302.html
   fonttools>=4.34.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,10 @@
 # 
 
 [tox]
-envlist = py39, py310, py311, py312, py313
+envlist = py310, py311, py312, py313
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
Support for Python 3.9 reached [end-of-life](https://devguide.python.org/versions/#supported-versions) in October 2025

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
