### PR TITLE
Fix license metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,13 @@ dynamic = ["version"]
 description = "Simple & fast PDF generation for Python"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
+license = "LGPL-3.0-only"
+license-files = ["LICENSE"]
 
 authors = [
   { name = "Olivier PLATHEY" },
   { name = "Max" },
-  { name = "Lucas Cimon" },
+  { name = "Lucas Cimon (@Lucas-C)" },
   { name = " Anderson Herzogenrath da Costa (@andersonhc)" }
 ]
 
@@ -22,7 +23,6 @@ keywords = ["pdf", "unicode", "png", "jpg", "ttf", "barcode", "library", "markdo
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -52,7 +52,7 @@ Code = "https://github.com/py-pdf/fpdf2"
 "Issue tracker" = "https://github.com/py-pdf/fpdf2/issues"
 
 [tool.setuptools]
-packages = ["fpdf"]
+packages = ["fpdf", "fpdf.data", "fpdf.data.color_profiles"]
 
 [tool.setuptools.package-data]
 fpdf = [
@@ -62,8 +62,6 @@ fpdf = [
 
 [tool.setuptools.dynamic]
 version = { attr = "fpdf.FPDF_VERSION" }
-
-
 
 [project.entry-points."mkdocs.plugins"]
 check_toc = "docs.plugins.check_toc:CheckTocPlugin"
@@ -75,7 +73,6 @@ log_cli_level = "WARN"
 
 [tool.flake8]
 ignore = ["E203", "E221", "E241", "E251", "E701", "E731", "W503"]
-
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Fix this warning from `python -m build`:
```
        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
```

And then this other warning:
```
setuptools.errors.InvalidConfigError: License classifiers have been superseded by license expressions (see https://peps.python.org/pep-0639/). Please remove:

License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
```

And also this other warning:
```
        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'fpdf.data' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'fpdf.data' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'fpdf.data' to be distributed and are
        already explicitly excluding 'fpdf.data' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************
```

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
