### PR TITLE
Fix CI pipeline for Python 3.10 with old dependencies

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -166,6 +166,8 @@ jobs:
           # Ensuring that those minimal versions remain compatible:
           sed -i '/requires-python/s/>=/~=/' pyproject.toml
           sed -i 's/>=/==/' pyproject.toml
+          # Removing field not supported in pyproject.toml at the time (prevent this: ValueError - invalid pyproject.toml config):
+          sed -i '/license.*=/d' pyproject.toml
           pip install .
           # Targeting only a subset of tests because: A) it's faster and B) some tests are dependant on a specific version of fonttools or Pillow
           # Deselect test involving TTF fonts due to differences with old fonttools version.


### PR DESCRIPTION
Removing 2 fields not supported in pyproject.toml at the time.
Prevent this: `ValueError - invalid pyproject.toml config`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
