### PR TITLE
Fix bug in tables borders rendering - close #1669

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ## [2.8.6] - Not released yet
 ### Added
 * support for SVG `<linearGradient>` and `<radialGradient>` elements - _cf._ [issue #1580](https://github.com/py-pdf/fpdf2/issues/1580) - thanks to @Ani07-05
+### Fixed
+* a bug when rendering empty tables with `INTERNAL` layout, that caused an extra border to be rendered due to an erroneous use of `list.index()` - _cf._ [issue #1669](https://github.com/py-pdf/fpdf2/issues/1669)
 
 ## [2.8.5] - 2025-10-29
 ### Added

--- a/fpdf/table.py
+++ b/fpdf/table.py
@@ -381,7 +381,9 @@ class Table:
             )  # already includes gutter for cells spanning multiple columns
             y2 = y1 + cell_height
 
-            cell_idx = row.cells.index(cell)
+            cell_idx = next(
+                i for i, row_cell in enumerate(row.cells) if row_cell is cell
+            )
             (
                 self._borders_layout.cell_style_getter(
                     row_idx=i,

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:best-practices"],
+  "labels": ["dependencies"],
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {

--- a/test/table/empty_table_with_internal_layout.pdf
+++ b/test/table/empty_table_with_internal_layout.pdf
@@ -1,0 +1,73 @@
+%PDF-1.3
+%éëñ¿
+1 0 obj
+<<
+/Count 1
+/Kids [3 0 R]
+/MediaBox [0 0 595.28 841.89]
+/Type /Pages
+>>
+endobj
+2 0 obj
+<<
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<<
+/Contents 4 0 R
+/Parent 1 0 R
+/Resources 6 0 R
+/Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Filter /FlateDecode
+/Length 155
+>>
+stream
+xœ;Ã0†wNÁ	mì@®ĞµgèÖ.]rıVjHqœˆLÖ§ÿUğ‰šàE‰Šfj_X’ªİO¼ï~6B3¯„Ä Á*T“wé6Â¹„Ä Ñ¦‰fv.V¶Î}Ùßíƒî	7G°ôY¾#J	ß×Ã,Î·0Âzüc^hº¦ÈrZ5Øâ‚„Å0¢~´ç@@¬Îµ0‘"
+endstream
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+6 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+endobj
+7 0 obj
+<<
+/CreationDate (D:19691231190000Z)
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000102 00000 n 
+0000000205 00000 n 
+0000000285 00000 n 
+0000000512 00000 n 
+0000000611 00000 n 
+0000000678 00000 n 
+trailer
+<<
+/Size 8
+/Root 2 0 R
+/Info 7 0 R
+/ID [<18546A04714117F12262C8961B0EC33E><18546A04714117F12262C8961B0EC33E>]
+>>
+startxref
+733
+%%EOF

--- a/test/table/test_table.py
+++ b/test/table/test_table.py
@@ -313,6 +313,18 @@ def test_table_with_internal_layout(tmp_path):
     assert_pdf_equal(pdf, HERE / "table_with_internal_layout.pdf", tmp_path)
 
 
+def test_empty_table_with_internal_layout(tmp_path):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Times", size=16)
+    with pdf.table(borders_layout="INTERNAL") as table:
+        for y in range(3):
+            row = table.row()
+            for x in range(3):
+                row.cell()
+    assert_pdf_equal(pdf, HERE / "empty_table_with_internal_layout.pdf", tmp_path)
+
+
 def test_table_with_minimal_layout(tmp_path):
     pdf = FPDF()
     pdf.add_page()


### PR DESCRIPTION
Fix a bug when rendering empty tables with `INTERNAL` layout, that caused an extra border to be rendered due to an erroneous use of `list.index()` - _cf._ [issue #1669](https://github.com/py-pdf/fpdf2/issues/1669)

In fact, I think a border-rendering issue could have occured each time there were cells considered EQUAL, based on the `dataclass` default `_eq__` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
