### PR TITLE
fix borb logo file path

### DIFF
--- a/docs/CombineWithBorb.md
+++ b/docs/CombineWithBorb.md
@@ -1,6 +1,6 @@
 # borb #
 
-![](https://borbpdf.com/assets/graphics/borb.svg)
+![](https://borbpdf.com/assets/img/borb.svg)
 
 Joris Schellekens made another excellent pure-Python library dedicated to reading & write PDF: [borb](https://github.com/jorisschellekens/borb/).
 He even wrote a very detailed e-book about it, available publicly there: [borb-examples](https://github.com/jorisschellekens/borb-examples/).


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
