### PR TITLE
[CI] Add check for broken links in our documentation

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -223,6 +223,13 @@ jobs:
           python -m mkdocs build
           pdoc --html -o public/ fpdf --template-dir docs/pdoc
           scripts/add_pdoc_to_search_index.py
+      - name: Look for broken links
+        uses: JustinBeckwith/linkinator-action@238b8147055854af764d8fe06d01b5daf027906c
+        with:
+          paths: public/
+          concurrency: 1
+          linksToSkip: code.google.com/p/pyfpdf
+          verbosity: DEBUG
       - name: Build contributors map 🗺️
         # As build_contributors_html_page.py can hang due to GitHub rate-limiting, we only execute this on master for now
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Currently pending this fixup: https://github.com/JustinBeckwith/linkinator-action/pull/234

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).