### PR TITLE
[CI] Fix borb SVG logo rendering in docs

### DIFF
--- a/docs/CombineWithBorb.md
+++ b/docs/CombineWithBorb.md
@@ -1,6 +1,6 @@
 # borb #
 
-![](https://borbpdf.com/assets/img/borb.svg)
+![](borb-logo.svg)
 
 Joris Schellekens made another excellent pure-Python library dedicated to reading & write PDF: [borb](https://github.com/jorisschellekens/borb/).
 He even wrote a very detailed e-book about it, available publicly there: [borb-examples](https://github.com/jorisschellekens/borb-examples/).

--- a/docs/Shapes.md
+++ b/docs/Shapes.md
@@ -48,7 +48,7 @@ pdf.output("circle.pdf")
 ```
 ![](circle.png)
 
-!!! warning "This method changed parameters in [release 2.8.1](https://github.com/py-pdf/fpdf2/releases/tag/2.8.0)"
+!!! warning "This method changed parameters in [release 2.8.1](https://github.com/py-pdf/fpdf2/releases/tag/2.8.1)"
 
 ## Ellipse ##
 

--- a/docs/borb-logo.svg
+++ b/docs/borb-logo.svg
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="210mm"
+   viewBox="0 0 210 210"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="borb.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="7.5741933"
+     inkscape:cy="442.47611"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="3840"
+     inkscape:window-height="2004"
+     inkscape:window-x="-16"
+     inkscape:window-y="-16"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-87)">
+    <path
+       style="fill:#675523;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+       d="m 137.24573,246.86484 5.33046,6.0268 6.78818,10.97492 4.03529,0.1971 -4.68855,-6.2123 6.56009,5.94967 3.55428,0.16917 0.23318,-2.41822 -6.80309,-4.96136 6.12841,2.19345 -1.03419,-3.29 -11.21435,-4.43777 -6.0643,-6.49634 -3.78579,1.58087 z"
+       id="path4737"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#675523;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+       d="m 147.98411,240.5006 5.33046,6.0268 6.78818,10.97492 4.03529,0.1971 -4.68855,-6.2123 6.56009,5.94967 3.55428,0.16917 0.23318,-2.41822 -6.80309,-4.96136 6.12841,2.19345 -1.03419,-3.29 -11.21435,-4.43777 -6.0643,-6.49634 -3.78579,1.58087 z"
+       id="path4737-4"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#f1cd2e;fill-opacity:1;stroke:none;stroke-width:0.28222224;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path815"
+       cx="96.350655"
+       cy="194.23486"
+       r="70.425522" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#675523;fill-opacity:1;stroke:none;stroke-width:0.17651856;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853"
+       cx="55.069489"
+       cy="210.37567"
+       r="13.728528" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#f1cd2e;fill-opacity:1;stroke:none;stroke-width:0.28222224;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853-4"
+       cx="64.643211"
+       cy="222.86839"
+       r="21.949511" />
+    <ellipse
+       style="opacity:1;vector-effect:none;fill:#675523;fill-opacity:1;stroke:none;stroke-width:0.41914862;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853-44"
+       cx="28.302319"
+       cy="216.73964"
+       rx="29.887011"
+       ry="35.556652"
+       transform="rotate(-22.479268)" />
+    <ellipse
+       style="opacity:1;vector-effect:none;fill:#675523;fill-opacity:1;stroke:none;stroke-width:0.19277938;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853-44-1"
+       cx="97.049957"
+       cy="220.81682"
+       rx="13.728527"
+       ry="16.374361"
+       transform="rotate(-11.237328)" />
+    <ellipse
+       style="opacity:1;vector-effect:none;fill:#f1cd2e;fill-opacity:1;stroke:none;stroke-width:0.43863648;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853-44-8"
+       cx="72.103981"
+       cy="198.74373"
+       rx="30.44281"
+       ry="38.228909"
+       transform="matrix(0.96822427,-0.25008351,0.20917175,0.97787892,0,0)" />
+    <ellipse
+       style="opacity:1;vector-effect:none;fill:#f1cd2e;fill-opacity:1;stroke:none;stroke-width:0.22502473;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853-44-8-0"
+       cx="87.751289"
+       cy="214.72678"
+       rx="15.712904"
+       ry="19.492666"
+       transform="rotate(-13.536879)" />
+    <ellipse
+       style="opacity:1;vector-effect:none;fill:#f1cd2e;fill-opacity:1;stroke:none;stroke-width:0.22578013;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853-44-8-8"
+       cx="92.277931"
+       cy="212.07285"
+       rx="21.288048"
+       ry="14.484475"
+       transform="rotate(-20.307296)" />
+    <ellipse
+       style="opacity:1;vector-effect:none;fill:#f1cd2e;fill-opacity:1;stroke:none;stroke-width:0.28630093;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path853-44-8-8-1"
+       cx="205.83859"
+       cy="40.305408"
+       rx="18.075249"
+       ry="27.430161"
+       transform="rotate(31.221323)" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#f1cd2e;fill-opacity:1;stroke:none;stroke-width:0.47838452;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 63.551791,233.11519 34.943395,212.31358 a 21.704834,63.777119 40.941674 0 0 -6.178064,25.51901 21.704834,63.777119 40.941674 0 0 34.78646,-4.7174 z"
+       id="path983"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#675523;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+       d="m 34.466247,244.20925 c 0,0 4.503926,-1.20616 8.315475,-5.62239 5.396321,-6.25242 2.096558,1.86023 2.096558,1.86023 0,0 -2.947003,3.95115 -10.412033,3.76216 z"
+       id="path4735"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscc" />
+  </g>
+</svg>

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2111,7 +2111,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         Outputs a circle.
         It can be drawn (border only), filled (with no border) or both.
 
-        WARNING: This method changed parameters in [release 2.8.0](https://github.com/py-pdf/fpdf2/releases/tag/2.8.0)
+        WARNING: This method changed parameters in [release 2.8.1](https://github.com/py-pdf/fpdf2/releases/tag/2.8.1)
 
         Args:
             x (float): Abscissa of upper-left bounding box.


### PR DESCRIPTION
Fixes this error with borb SVG logo:
```
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/fpdf2/fpdf2/.cache/plugin/privacy/assets/external/borbpdf.com/assets/img/borb.svg'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).