### PR TITLE
Preserve formatting characters on bidirectional text preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ## [2.8.8] - Not released yet
 ### Fixed
 * text rendering when the first text on a page starts with a fallback glyph
+* preserve boundary-neutral formatting during bidirectional text preprocessing
 ### Changed
 * skip byte-for-byte compressed data comparison when zlib-ng is detected, regardless of OS
 

--- a/fpdf/bidi.py
+++ b/fpdf/bidi.py
@@ -539,6 +539,7 @@ class BidiParagraph:
         "text",
         "base_direction",
         "debug",
+        "preserve_bn_chars",
         "base_embedding_level",
         "characters",
     )
@@ -548,6 +549,7 @@ class BidiParagraph:
         text: str,
         base_direction: Optional[TextDirection] = None,
         debug: bool = False,
+        preserve_bn_chars: bool = False,
     ) -> None:
         self.text = text
         self.base_direction = (
@@ -556,6 +558,7 @@ class BidiParagraph:
             else base_direction
         )
         self.debug = debug
+        self.preserve_bn_chars = preserve_bn_chars
         self.base_embedding_level = (
             0 if self.base_direction == TextDirection.LTR else 1
         )  # base level
@@ -701,13 +704,17 @@ class BidiParagraph:
 
             if new_bidi_class:
                 bidi_char.bidi_class = new_bidi_class
-            if bidi_char.bidi_class not in (
-                "RLE",
-                "LRE",
-                "RLO",
-                "LRO",
-                "PDF",
-                "BN",
+            if (
+                bidi_char.bidi_class
+                not in (
+                    "RLE",
+                    "LRE",
+                    "RLO",
+                    "LRO",
+                    "PDF",
+                    "BN",
+                )
+                or self.preserve_bn_chars
             ):  # X9
                 if bidi_char.bidi_class == "B":
                     bidi_char.embedding_level = self.base_embedding_level

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -4332,7 +4332,11 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             else auto_detect_base_direction(text)
         )
 
-        paragraph = BidiParagraph(text=text, base_direction=paragraph_direction)
+        paragraph = BidiParagraph(
+            text=text,
+            base_direction=paragraph_direction,
+            preserve_bn_chars=True,
+        )
         directional_segments = paragraph.get_bidi_fragments()
         self.text_shaping["paragraph_direction"] = paragraph.base_direction
 

--- a/test/text_shaping/test_bidirectional.py
+++ b/test/text_shaping/test_bidirectional.py
@@ -274,3 +274,18 @@ def test_bidi_get_string_width(tmp_path):
         pdf.ln()
     pdf.ln()
     assert_pdf_equal(pdf, HERE / "bidi_get_string_width.pdf", tmp_path)
+
+
+def test_bidi_preserves_bn_chars():
+    paragraph = BidiParagraph(
+        text="This is an in\u00adter\U000e007ana\u00adtion\u00adal",
+        base_direction=TextDirection.LTR,
+        preserve_bn_chars=True,
+    )
+
+    assert paragraph.get_bidi_fragments() == (
+        ("This is an in\u00adter\U000e007ana\u00adtion\u00adal", TextDirection.LTR),
+    )
+    characters = [char.character for char in paragraph.get_characters()]
+    assert characters.count("\u00ad") == 3
+    assert characters.count("\U000e007a") == 1

--- a/test/text_shaping/test_text_shaping.py
+++ b/test/text_shaping/test_text_shaping.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from fpdf import FPDF
+from fpdf.enums import MethodReturnValue
 from fpdf.unicode_script import get_unicode_script, UnicodeScript
 from test.conftest import assert_pdf_equal
 
@@ -179,6 +180,31 @@ def test_text_shaping_and_offset_rendering(tmp_path):  # issue #1075
             pdf.cell(col_width, line_height, f"Cell ({i})")
         pdf.cell(col_width, line_height, f"Cell ({i})")
     assert_pdf_equal(pdf, HERE / "text_shaping_and_offset_rendering.pdf", tmp_path)
+
+
+def test_multi_cell_uses_soft_hyphen_with_text_shaping():
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.add_font("Roboto", "", FONTS_DIR / "Roboto-Regular.ttf")
+    pdf.set_font("Roboto", size=12)
+    pdf.set_text_shaping(
+        use_shaping_engine=True,
+        direction="ltr",
+        script="latn",
+        language="eng",
+    )
+
+    lines = pdf.multi_cell(
+        w=50,
+        text="This is an in\u00adter\u00adna\u00adtion\u00adal\u00adiza\u00adtion example.",
+        dry_run=True,
+        output=MethodReturnValue.LINES,
+    )
+
+    assert lines == [
+        "This is an international-",
+        "ization example.",
+    ]
 
 
 def test_multilingual_string(tmp_path):


### PR DESCRIPTION
When applying rule X9, don't drop BN characters on real text preprocessing

Fixes #1779 

**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [x] A unit test is covering the code added / modified by this PR

- [x] A mention of the change is present in `CHANGELOG.md`

- [x] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->

<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
