### PR TITLE
Fix table data px dimension parsing bug

### DIFF
--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -1125,6 +1125,9 @@ class HTML2FPDF(HTMLParser):
             if not self.table or not self.table_row:
                 raise FPDFException(f"Invalid HTML: <{tag}> used outside any <tr>")
             self.td_th = {k.lower(): v for k, v in attrs_dict.items()}
+            for dimension in ("width", "height"):
+            if dimension in self.td_th and self.td_th[dimension] is not None:
+                self.td_th[dimension] = self.td_th[dimension].replace("px", "").strip()
             self.td_th["tag"] = tag
             if tag == "th":
                 if "align" not in self.td_th:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Some guidelines are provided like this, in HTML comments, to expedite the code review before merging your contribution.

First, please make sure that you have read the documentation page on fpdf2 development:
https://py-pdf.github.io/fpdf2/Development.html

If you're new to contributing to open source projects,
you might find this free video course helpful: http://kcd.im/pull-request
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

e.g. Fixes #0 <!-- This will automatically close issue #0 once the PR is merged: https://help.github.com/en/articles/closing-issues-using-keywords -->

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] A unit test is covering the code added / modified by this PR N/A

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder N/A

- [ ] A mention of the change is present in `CHANGELOG.md` N/A

- [x] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->
Added a .replace("px", "") strip to safely handle pixel dimensions during HTML table parsing.
<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
