### PR TITLE
Add configurable resource access policy for image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ## [2.8.8] - Not released yet
 ### Added
 * Punjabi (pa) tutorial translation - thanks to @Pawansingh3889
+* `resource_access_policy` and [Security considerations](https://py-pdf.github.io/fpdf2/Security.html) documentation
 ### Fixed
 * text rendering when the first text on a page starts with a fallback glyph - _cf._ [issue #1772](https://github.com/py-pdf/fpdf2/issues/1772)
 * preserve boundary-neutral formatting during bidirectional text preprocessing - _cf._ [issue #1779](https://github.com/py-pdf/fpdf2/issues/1779)

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,0 +1,94 @@
+# Security
+
+## Security model
+
+`fpdf2` operates on content and resource references explicitly provided to it. As a result, applications integrating `fpdf2` are responsible for validating untrusted input, enforcing appropriate filesystem and network restrictions, and choosing safe defaults for their deployment environment.
+
+`fpdf2` is therefore only as secure as the application and runtime environment using it.
+
+## Untrusted content
+
+Extra care must be taken when rendering content formats that can reference additional resources, including:
+
+- HTML via `write_html()`
+- SVG images via `image()`
+- template-driven image paths
+- direct image paths or URLs passed to `image()`
+
+These formats may contain references to local files or remote resources. If such content is attacker-controlled, it can cause the library to attempt to load those resources unless access is restricted.
+
+Applications should avoid rendering untrusted HTML, SVG, or image paths without validation or an appropriate `resource_access_policy`.
+
+## Built-in protections
+
+`fpdf2` includes protections against some common parser-related attacks.
+
+For example, SVG/XML parsing uses hardened XML handling intended to mitigate classes of attacks such as exponential entity expansion ("Billion Laughs"-style attacks).
+
+These protections reduce risk in specific parsing paths, but they do not replace safe application design or input validation.
+
+## Resource access policy
+
+To reduce the risk of unintended local file access or outbound network requests, `fpdf2` provides a configurable `resource_access_policy`.
+
+This policy controls which resource types may be loaded while rendering content.
+
+Example:
+
+```python
+from fpdf import FPDF, ResourceAccessPolicy
+
+pdf = FPDF()
+pdf.resource_access_policy = (
+    ResourceAccessPolicy.LOCAL_FILES | ResourceAccessPolicy.REMOTE_PUBLIC
+)
+````
+
+The policy applies globally to the `FPDF` instance and affects all resource loading performed through that document, including nested resources referenced from HTML or SVG.
+
+By default, `fpdf2` restricts resource loading to local files and remote HTTP(S) resources that resolve to public network addresses. Access to private, loopback, and link-local network targets is blocked.
+
+## Per-call override with `image()`
+
+The `image()` method also accepts a `resource_access_policy` argument that overrides the document-wide setting for that specific call:
+
+```python
+from fpdf import FPDF, ResourceAccessPolicy
+
+pdf = FPDF()
+pdf.resource_access_policy = ResourceAccessPolicy.NONE
+
+pdf.image(
+    "https://example.com/logo.png",
+    x=10,
+    y=10,
+    w=20,
+    resource_access_policy=ResourceAccessPolicy.REMOTE_PUBLIC,
+)
+```
+
+This override also applies to nested raster resources referenced from SVG files loaded through that `image()` call.
+
+## Recommended usage
+
+When an application may handle user-provided or partially trusted content, prefer keeping the document-wide `resource_access_policy` restrictive and using per-call overrides only for specific trusted resources.
+
+This is safer than relaxing the main policy for the entire `FPDF` instance.
+
+Recommended pattern:
+
+* keep `pdf.resource_access_policy` as strict as practical
+* use `image(..., resource_access_policy=...)` only where a specific trusted resource needs broader access
+* avoid changing the global policy to accommodate a single image source
+
+This is especially important in applications that expose PDF generation features to end users.
+
+## Additional recommendations
+
+Applications using `fpdf2` with untrusted input should also consider:
+
+* sanitizing or rejecting untrusted HTML and SVG content
+* validating image paths and URLs before passing them to `fpdf2`
+* applying network egress restrictions at the infrastructure level
+* limiting filesystem access for the process running PDF generation
+* running document generation in isolated environments when appropriate

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -42,7 +42,7 @@ pdf = FPDF()
 pdf.resource_access_policy = (
     ResourceAccessPolicy.LOCAL_FILES | ResourceAccessPolicy.REMOTE_PUBLIC
 )
-````
+```
 
 The policy applies globally to the `FPDF` instance and affects all resource loading performed through that document, including nested resources referenced from HTML or SVG.
 

--- a/fpdf/__init__.py
+++ b/fpdf/__init__.py
@@ -4,10 +4,12 @@ Gives direct access to some classes defined in submodules:
 
 * `fpdf.fpdf.FPDF`
 * `fpdf.enums.Align`
+* `fpdf.enums.ResourceAccessPolicy`
 * `fpdf.enums.TextMode`
 * `fpdf.enums.XPos`
 * `fpdf.enums.YPos`
 * `fpdf.errors.FPDFException`
+* `fpdf.errors.FPDFResourceAccessError`
 * `fpdf.fonts.FontFace`
 * `fpdf.fonts.TextStyle`
 * `fpdf.prefs.ViewerPreferences`
@@ -19,8 +21,8 @@ import sys
 import warnings
 
 from .deprecation import WarnOnDeprecatedModuleAttributes
-from .enums import Align, TextMode, XPos, YPos
-from .errors import FPDFException
+from .enums import Align, ResourceAccessPolicy, TextMode, XPos, YPos
+from .errors import FPDFException, FPDFResourceAccessError
 from .fonts import FontFace, TextStyle
 from .fpdf import (
     FPDF,
@@ -68,8 +70,10 @@ __all__ = [
     # Classes:
     "FPDF",
     "FPDFException",
+    "FPDFResourceAccessError",
     "FontFace",
     "Align",
+    "ResourceAccessPolicy",
     "TextMode",
     "XPos",
     "YPos",

--- a/fpdf/enums.py
+++ b/fpdf/enums.py
@@ -1,6 +1,6 @@
 import abc
 from dataclasses import dataclass
-from enum import Enum, Flag, IntEnum, IntFlag
+from enum import Enum, Flag, IntEnum, IntFlag, auto
 from sys import intern
 from typing import (
     TYPE_CHECKING,
@@ -31,6 +31,19 @@ class SignatureFlag(IntEnum):
     if the file is saved (written) in a way that alters its previous contents,
     as opposed to an incremental update.
     """
+
+
+class ResourceAccessPolicy(Flag):
+    "Defines which external and local resources fpdf2 may load implicitly."
+
+    NONE = 0
+    LOCAL_FILES = auto()
+    REMOTE_PUBLIC = auto()
+    REMOTE_PRIVATE = auto()
+
+    REMOTE_ALL = REMOTE_PUBLIC | REMOTE_PRIVATE
+    ALL = LOCAL_FILES | REMOTE_ALL
+    DEFAULT = LOCAL_FILES | REMOTE_PUBLIC
 
 
 E = TypeVar("E", bound="CoerciveEnum")

--- a/fpdf/errors.py
+++ b/fpdf/errors.py
@@ -2,6 +2,10 @@ class FPDFException(Exception):
     pass
 
 
+class FPDFResourceAccessError(FPDFException):
+    """Raised when loading a resource violates the active resource access policy."""
+
+
 class FPDFPageFormatException(FPDFException):
     """Error is thrown when a bad page format is given"""
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -108,6 +108,7 @@ from .enums import (
     PageOrientation,
     PathPaintRule,
     PDFResourceType,
+    ResourceAccessPolicy,
     RenderStyle,
     TextDirection,
     TextEmphasis,
@@ -352,6 +353,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         )  # map names to Destination objects
         self.embedded_files: list[PDFEmbeddedFile] = []  # array of PDFEmbeddedFile
         self.image_cache = ImageCache()
+        self.resource_access_policy = ResourceAccessPolicy.DEFAULT
         self.in_footer = False  # flag set while rendering footer
         # indicates that we are inside an .unbreakable() code block:
         self._in_unbreakable = False
@@ -5203,6 +5205,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         alt_text: Optional[str] = None,
         dims: Optional[tuple[float, float]] = None,
         keep_aspect_ratio: bool = False,
+        resource_access_policy: Optional[ResourceAccessPolicy] = None,
     ) -> RasterImageInfo | VectorImageInfo:
         """
         Put an image on the page.
@@ -5248,6 +5251,9 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             keep_aspect_ratio (bool): ensure the image fits in the rectangle defined by `x`, `y`, `w` & `h`
                 while preserving its original aspect ratio. Defaults to False.
                 Only meaningful if both `w` & `h` are provided.
+            resource_access_policy (fpdf.enums.ResourceAccessPolicy, optional): override
+                the document-level policy used to load local or remote image resources
+                for this call, including nested raster images referenced by SVG files.
 
         If `y` is provided, this method will not trigger any page break;
         otherwise, auto page break detection will be performed.
@@ -5266,7 +5272,15 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
                 stacklevel=get_stack_level(),
             )
 
-        name, img, info = preload_image(self.image_cache, name, dims)
+        if resource_access_policy is None:
+            resource_access_policy = self.resource_access_policy
+
+        name, img, info = preload_image(
+            self.image_cache,
+            name,
+            dims,
+            resource_access_policy=resource_access_policy,
+        )
         if isinstance(info, VectorImageInfo):
             return self._vector_image(
                 name,
@@ -5296,6 +5310,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             alt_text,
             dims,
             keep_aspect_ratio,
+            resource_access_policy,
         )
 
     def _raster_image(
@@ -5312,6 +5327,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         alt_text: Optional[str] = None,
         dims: Optional[tuple[float, float]] = None,
         keep_aspect_ratio: bool = False,
+        resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.ALL,
     ) -> RasterImageInfo:
         if "smask" in info:
             self._set_min_pdf_version("1.4")
@@ -5334,7 +5350,15 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         if keep_aspect_ratio:
             x, y, w, h = info.scale_inside_box(x, y, w, h)
         if self.oversized_images and info["usages"] == 1 and not dims:
-            info = self._downscale_image(name, img, info, w, h, scale=self.k)
+            info = self._downscale_image(
+                name,
+                img,
+                info,
+                w,
+                h,
+                scale=self.k,
+                resource_access_policy=resource_access_policy,
+            )
 
         stream_content = stream_content_for_raster_image(
             info, x, y, w, h, keep_aspect_ratio, scale=self.k, pdf_height_to_flip=self.h
@@ -5473,6 +5497,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         w: float,
         h: float,
         scale: float,
+        resource_access_policy: ResourceAccessPolicy,
     ) -> RasterImageInfo:
         images = self.image_cache.images
         width_in_pt, height_in_pt = w * scale, h * scale
@@ -5521,9 +5546,14 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
                         info.update(
                             get_img_info(
                                 name,
-                                img or load_image(name),
+                                img
+                                or load_image(
+                                    name,
+                                    resource_access_policy=resource_access_policy,
+                                ),
                                 self.image_cache.image_filter,
                                 dims,
+                                resource_access_policy=resource_access_policy,
                             )
                         )
                         LOGGER.debug(
@@ -5537,9 +5567,14 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
                     info = RasterImageInfo(
                         get_img_info(
                             name,
-                            img or load_image(name),
+                            img
+                            or load_image(
+                                name,
+                                resource_access_policy=resource_access_policy,
+                            ),
                             self.image_cache.image_filter,
                             dims,
+                            resource_access_policy=resource_access_policy,
                         )
                     )
                     info["i"] = len(images) + 1
@@ -5585,6 +5620,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             self.image_cache,
             name,  # pyright: ignore[reportArgumentType, reportReturnType]
             dims,
+            resource_access_policy=self.resource_access_policy,
         )
 
     def preload_glyph_image(self, glyph_image_bytes: bytes | BinaryIO) -> tuple[
@@ -5596,6 +5632,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             image_cache=self.image_cache,
             name=glyph_image_bytes,
             dims=None,  # pyright: ignore[reportArgumentType, reportReturnType]
+            resource_access_policy=self.resource_access_policy,
         )
 
     @contextmanager

--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -2,8 +2,10 @@
 # mypy: disable-error-code=no-untyped-call
 import base64
 import hashlib
+import ipaddress
 import io
 import logging
+import socket
 import zlib
 from dataclasses import dataclass
 from io import BytesIO
@@ -20,9 +22,11 @@ from typing import (
     Union,
     no_type_check,
 )
-from urllib.request import urlopen
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
-from .errors import FPDFException
+from .enums import ResourceAccessPolicy
+from .errors import FPDFException, FPDFResourceAccessError
 from .image_datastructures import (
     ImageCache,
     ImageFilter,
@@ -63,11 +67,108 @@ except ImportError:
 class ImageSettings:
     # Passed to zlib.compress() - In range 0-9 - Default is currently equivalent to 6:
     compression_level: int = -1
+    # Applied to remote HTTP(S) image fetches. Set to None to use the Python default.
+    network_timeout: float | None = 10.0
 
 
 LOGGER = logging.getLogger(__name__)
 SUPPORTED_IMAGE_FILTERS = ("AUTO", "FlateDecode", "DCTDecode", "JPXDecode", "LZWDecode")
 SETTINGS = ImageSettings()
+
+
+def _resource_scope_for_ip(
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> tuple[ResourceAccessPolicy, str]:
+    if address.is_global:
+        return ResourceAccessPolicy.REMOTE_PUBLIC, "public"
+    return ResourceAccessPolicy.REMOTE_PRIVATE, "private"
+
+
+def _resolve_hostname(
+    hostname: str,
+) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...]:
+    try:
+        addr_info = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as error:
+        raise FPDFResourceAccessError(
+            f"Could not resolve remote resource hostname: {hostname!r}"
+        ) from error
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    seen: set[str] = set()
+    for addr in addr_info:
+        sockaddr = addr[4]
+        address_value = sockaddr[0]
+        if not isinstance(address_value, str):
+            continue
+        address = address_value.split("%", 1)[0]
+        if address in seen:
+            continue
+        seen.add(address)
+        addresses.append(ipaddress.ip_address(address))
+    if not addresses:
+        raise FPDFResourceAccessError(
+            f"Could not resolve any IP address for remote resource hostname: {hostname!r}"
+        )
+    return tuple(addresses)
+
+
+def _validate_remote_url_access(
+    url: str,
+    resource_access_policy: ResourceAccessPolicy,
+) -> None:
+    parsed_url = urlsplit(url)
+    if parsed_url.scheme not in ("http", "https") or not parsed_url.hostname:
+        raise FPDFResourceAccessError(f"Unsupported remote resource URL: {url!r}")
+    if not resource_access_policy & ResourceAccessPolicy.REMOTE_ALL:
+        raise FPDFResourceAccessError(
+            f"Remote resource access is disabled by resource_access_policy: {url!r}"
+        )
+
+    for address in _resolve_hostname(parsed_url.hostname):
+        required_policy, scope = _resource_scope_for_ip(address)
+        if resource_access_policy & required_policy:
+            continue
+        raise FPDFResourceAccessError(
+            "Remote resource access is blocked by resource_access_policy: "
+            f"{url!r} resolves to {scope} address {address}"
+        )
+
+
+def _validate_resource_access(
+    filename: Any,
+    resource_access_policy: ResourceAccessPolicy,
+) -> None:
+    if isinstance(filename, Path):
+        filename = str(filename)
+    if not isinstance(filename, str):
+        return
+    if filename.startswith("data:"):
+        return
+    if filename.startswith(("http://", "https://")):
+        _validate_remote_url_access(filename, resource_access_policy)
+        return
+    if not resource_access_policy & ResourceAccessPolicy.LOCAL_FILES:
+        raise FPDFResourceAccessError(
+            f"Local file access is disabled by resource_access_policy: {filename!r}"
+        )
+
+
+class _ResourceAccessPolicyRedirectHandler(HTTPRedirectHandler):
+    def __init__(self, resource_access_policy: ResourceAccessPolicy) -> None:
+        super().__init__()
+        self.resource_access_policy = resource_access_policy
+
+    def redirect_request(
+        self,
+        req: Any,
+        fp: Any,
+        code: Any,
+        msg: Any,
+        headers: Any,
+        newurl: str,
+    ) -> Optional[Request]:
+        _validate_remote_url_access(newurl, self.resource_access_policy)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
 # fmt: off
@@ -111,6 +212,7 @@ def preload_image(
     image_cache: ImageCache,
     name: ImageType,
     dims: Optional[tuple[float, float]] = None,
+    resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
 ) -> tuple[
     str,
     Union[SVGObject, "PILImage", bytes, BinaryIO, Path, None],
@@ -134,18 +236,33 @@ def preload_image(
     Returns: A tuple, consisting of 3 values: the name, the image data,
         and an instance of a subclass of `ImageInfo`.
     """
+    _validate_resource_access(name, resource_access_policy)
+
     # Identify and load SVG data:
     if isinstance(name, (str, Path)) and str(name).endswith(".svg"):
         try:
             return get_svg_info(
-                str(name), load_image(str(name)), image_cache=image_cache
+                str(name),
+                load_image(str(name), resource_access_policy=resource_access_policy),
+                image_cache=image_cache,
+                resource_access_policy=resource_access_policy,
             )
         except Exception as error:
             raise ValueError(f"Could not parse file: {name}") from error
     if isinstance(name, bytes) and _is_svg(name.strip()):
-        return get_svg_info("vector_image", io.BytesIO(name), image_cache=image_cache)
+        return get_svg_info(
+            "vector_image",
+            io.BytesIO(name),
+            image_cache=image_cache,
+            resource_access_policy=resource_access_policy,
+        )
     if isinstance(name, io.BytesIO) and _is_svg(name.getvalue().strip()):
-        return get_svg_info("vector_image", name, image_cache=image_cache)
+        return get_svg_info(
+            "vector_image",
+            name,
+            image_cache=image_cache,
+            resource_access_policy=resource_access_policy,
+        )
 
     # Load raster data.
     img: Union["PILImage", bytes, BinaryIO, Path, None]
@@ -176,6 +293,7 @@ def preload_image(
             img,
             image_cache.image_filter,
             dims,
+            resource_access_policy=resource_access_policy,
         )
         info["i"] = len(image_cache.images) + 1
         info["usages"] = 1
@@ -211,7 +329,10 @@ def _is_binary_stream(obj: Any) -> TypeGuard[BinaryIO]:
     return hasattr(obj, "read") and not isinstance(obj, (str, Path))
 
 
-def load_image(filename: str | Path | BinaryIO) -> BinaryIO:
+def load_image(
+    filename: str | Path | BinaryIO,
+    resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
+) -> BinaryIO:
     """
     This method is used to load external resources, such as images.
     It is automatically called when resource added to document by `fpdf.fpdf.FPDF.image()`.
@@ -225,11 +346,17 @@ def load_image(filename: str | Path | BinaryIO) -> BinaryIO:
         return BytesIO(filename.read())
     if isinstance(filename, Path):
         filename = str(filename)
-    # by default loading from network is allowed for all images
+    _validate_resource_access(filename, resource_access_policy)
+    # Resource access is governed by the active resource_access_policy.
     if filename.startswith(("http://", "https://")):
+        opener = build_opener(
+            _ResourceAccessPolicyRedirectHandler(resource_access_policy)
+        )
         # disabling bandit & semgrep rules as permitted schemes are whitelisted:
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-        with urlopen(filename) as url_file:  # nosec B310
+        with opener.open(
+            filename, timeout=SETTINGS.network_timeout
+        ) as url_file:  # nosec B310
             return BytesIO(url_file.read())
     elif filename.startswith("data:"):
         return _decode_base64_image(filename)
@@ -267,11 +394,18 @@ def is_iccp_valid(iccp: bytes, filename: str | Path) -> bool:
 
 
 def get_svg_info(
-    filename: str, img: BinaryIO, image_cache: ImageCache
+    filename: str,
+    img: BinaryIO,
+    image_cache: ImageCache,
+    resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
 ) -> tuple[str, SVGObject, VectorImageInfo]:
     img.seek(0)
     svg_data = img.read()
-    svg = SVGObject(svg_data, image_cache=image_cache)
+    svg = SVGObject(
+        svg_data,
+        image_cache=image_cache,
+        resource_access_policy=resource_access_policy,
+    )
     if svg.viewbox:
         _, _, w, h = svg.viewbox
     else:
@@ -289,6 +423,7 @@ def get_img_info(
     img: Union["PILImage", bytes, BinaryIO, Path, str, None] = None,
     image_filter: ImageFilter = "AUTO",
     dims: Optional[tuple[float, float]] = None,
+    resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
 ) -> RasterImageInfo:
     """
     Args:
@@ -306,7 +441,9 @@ def get_img_info(
     jpeg_inverted = False
     img_raw_data: Optional[BinaryIO] = None
     if not img or isinstance(img, (Path, str)):
-        img_raw_data = load_image(filename)
+        img_raw_data = load_image(
+            filename, resource_access_policy=resource_access_policy
+        )
         img = Image.open(img_raw_data)
         is_pil_img = False
     elif not _is_pil_image(img):

--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -119,14 +119,17 @@ def _validate_remote_url_access(
     parsed_url = urlsplit(url)
     if parsed_url.scheme not in ("http", "https") or not parsed_url.hostname:
         raise FPDFResourceAccessError(f"Unsupported remote resource URL: {url!r}")
-    if not resource_access_policy & ResourceAccessPolicy.REMOTE_ALL:
+    if (
+        ResourceAccessPolicy.REMOTE_PUBLIC not in resource_access_policy
+        and ResourceAccessPolicy.REMOTE_PRIVATE not in resource_access_policy
+    ):
         raise FPDFResourceAccessError(
             f"Remote resource access is disabled by resource_access_policy: {url!r}"
         )
 
     for address in _resolve_hostname(parsed_url.hostname):
         required_policy, scope = _resource_scope_for_ip(address)
-        if resource_access_policy & required_policy:
+        if required_policy in resource_access_policy:
             continue
         raise FPDFResourceAccessError(
             "Remote resource access is blocked by resource_access_policy: "
@@ -139,7 +142,12 @@ def _validate_resource_access(
     resource_access_policy: ResourceAccessPolicy,
 ) -> None:
     if isinstance(filename, Path):
-        filename = str(filename)
+        if ResourceAccessPolicy.LOCAL_FILES not in resource_access_policy:
+            raise FPDFResourceAccessError(
+                "Local file access is disabled by resource_access_policy: "
+                f"{filename!r}"
+            )
+        return
     if not isinstance(filename, str):
         return
     if filename.startswith("data:"):
@@ -147,7 +155,7 @@ def _validate_resource_access(
     if filename.startswith(("http://", "https://")):
         _validate_remote_url_access(filename, resource_access_policy)
         return
-    if not resource_access_policy & ResourceAccessPolicy.LOCAL_FILES:
+    if ResourceAccessPolicy.LOCAL_FILES not in resource_access_policy:
         raise FPDFResourceAccessError(
             f"Local file access is disabled by resource_access_policy: {filename!r}"
         )
@@ -236,14 +244,26 @@ def preload_image(
     Returns: A tuple, consisting of 3 values: the name, the image data,
         and an instance of a subclass of `ImageInfo`.
     """
-    _validate_resource_access(name, resource_access_policy)
+    if isinstance(name, Path):
+        if ResourceAccessPolicy.LOCAL_FILES not in resource_access_policy:
+            raise FPDFResourceAccessError(
+                "Local file access is disabled by resource_access_policy: " f"{name!r}"
+            )
+        name = str(name)
+        if not name.endswith(".svg"):
+            info = image_cache.images.get(name)
+            if info is not None:
+                info["usages"] = info["usages"] + 1  # type: ignore[operator]
+                return name, None, info
+    else:
+        _validate_resource_access(name, resource_access_policy)
 
     # Identify and load SVG data:
-    if isinstance(name, (str, Path)) and str(name).endswith(".svg"):
+    if isinstance(name, str) and name.endswith(".svg"):
         try:
             return get_svg_info(
-                str(name),
-                load_image(str(name), resource_access_policy=resource_access_policy),
+                name,
+                load_image(name, resource_access_policy=resource_access_policy),
                 image_cache=image_cache,
                 resource_access_policy=resource_access_policy,
             )
@@ -286,7 +306,7 @@ def preload_image(
         raster_name, img = str(name), name
     else:
         raster_name, img = str(name), None
-    info: RasterImageInfo | VectorImageInfo | None = image_cache.images.get(raster_name)
+    info = image_cache.images.get(raster_name)
     if info is not None:
         info["usages"] = info["usages"] + 1  # type: ignore[operator]
     else:

--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -247,6 +247,8 @@ def preload_image(
                 image_cache=image_cache,
                 resource_access_policy=resource_access_policy,
             )
+        except FPDFResourceAccessError:
+            raise
         except Exception as error:
             raise ValueError(f"Could not parse file: {name}") from error
     if isinstance(name, bytes) and _is_svg(name.strip()):

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -1442,21 +1442,28 @@ class SVGObject:
             debug_stream (io.TextIO): *DEPRECATED* the stream to which rendering debug info will be
                 written.
         """
+        previous_image_cache = self.image_cache
+        previous_resource_access_policy = self.resource_access_policy
         self.image_cache = pdf.image_cache  # Needed to render images
-        _, _, path = self.transform_to_page_viewport(pdf)
-
-        old_x, old_y = pdf.x, pdf.y
+        self.resource_access_policy = pdf.resource_access_policy
         try:
-            if x is not None and y is not None:
-                pdf.set_xy(0, 0)
-                assert path.transform is not None
-                path.transform = path.transform @ Transform.translation(x, y)
+            _, _, path = self.transform_to_page_viewport(pdf)
 
-            apply_svg_transform_to_user_space_gradients(path)
-            pdf.draw_path(path, debug_stream)
+            old_x, old_y = pdf.x, pdf.y
+            try:
+                if x is not None and y is not None:
+                    pdf.set_xy(0, 0)
+                    assert path.transform is not None
+                    path.transform = path.transform @ Transform.translation(x, y)
 
+                apply_svg_transform_to_user_space_gradients(path)
+                pdf.draw_path(path, debug_stream)
+
+            finally:
+                pdf.set_xy(old_x, old_y)
         finally:
-            pdf.set_xy(old_x, old_y)
+            self.image_cache = previous_image_cache
+            self.resource_access_policy = previous_resource_access_policy
 
     # defs paths are not drawn immediately but are added to xrefs and can be referenced
     # later to be drawn.

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -22,7 +22,13 @@ from fontTools.svgLib.path import (
     parse_path,  # pyright: ignore[reportUnknownVariableType]
 )
 
-from .enums import GradientSpreadMethod, GradientUnits, PathPaintRule, StrokeCapStyle
+from .enums import (
+    GradientSpreadMethod,
+    GradientUnits,
+    PathPaintRule,
+    ResourceAccessPolicy,
+    StrokeCapStyle,
+)
 
 try:
     from defusedxml.ElementTree import fromstring as parse_xml_str
@@ -899,9 +905,13 @@ class SVGObject:
             return cls(svgfile.read(), *args, **kwargs)
 
     def __init__(
-        self, svg_text: str | bytes, image_cache: Optional[ImageCache] = None
+        self,
+        svg_text: str | bytes,
+        image_cache: Optional[ImageCache] = None,
+        resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
     ) -> None:
         self.image_cache = image_cache  # Needed to render images
+        self.resource_access_policy = resource_access_policy
         self.cross_references: dict[str, Any] = {}
         self.css_class_styles: dict[str, dict[str, Any]] = {}
         self.gradient_definitions: dict[str, GradientPaint] = (
@@ -1918,7 +1928,11 @@ class SVGImage(NamedTuple):
         # pylint: disable=cyclic-import,import-outside-toplevel
         from .image_parsing import preload_image
 
-        _, _, info = preload_image(image_cache, self.href)
+        _, _, info = preload_image(
+            image_cache,
+            self.href,
+            resource_access_policy=self.svg_obj.resource_access_policy,
+        )
         if isinstance(info, VectorImageInfo):
             LOGGER.warning(
                 "Inserting .svg vector graphics in <image> tags is currently not supported (contributions are welcome to add support for it)"

--- a/fpdf/text_region.py
+++ b/fpdf/text_region.py
@@ -371,6 +371,7 @@ class ImageParagraph:
                 alt_text=self.alt_text,
                 dims=None,
                 keep_aspect_ratio=self.keep_aspect_ratio,
+                resource_access_policy=self.region.pdf.resource_access_policy,
             )
         )
         return return_info

--- a/fpdf/text_region.py
+++ b/fpdf/text_region.py
@@ -296,7 +296,9 @@ class ImageParagraph:
         # We do double duty as a "text line wrapper" here, since all the necessary
         # information is already in the ImageParagraph object.
         self.name, self.img, self.info = preload_image(
-            self.region.pdf.image_cache, self.name
+            self.region.pdf.image_cache,
+            self.name,
+            resource_access_policy=self.region.pdf.resource_access_policy,
         )
         return self
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,6 +201,7 @@ nav:
   - 'Development guidelines':         'Development.md'
   - 'Logging':                        'Logging.md'
   - 'fpdf2 internals':                'Internals.md'
+- 'Security considerations':          'Security.md'
 - 'API':                              'https://py-pdf.github.io/fpdf2/fpdf/'
 - 'Changelog':                        'https://github.com/py-pdf/fpdf2/blob/master/CHANGELOG.md'
 - 'History':                          'History.md'

--- a/test/image/test_load_image.py
+++ b/test/image/test_load_image.py
@@ -1,6 +1,10 @@
 import binascii
+import socket
 from glob import glob
+from io import BytesIO
 from pathlib import Path
+from unittest.mock import patch
+from urllib.request import Request
 
 import pytest
 
@@ -9,6 +13,46 @@ import fpdf
 from test.conftest import assert_pdf_equal, ensure_rss_memory_below, time_execution
 
 HERE = Path(__file__).resolve().parent
+PNG_BYTES = (HERE / "png_images/c636287a4d7cb1a36362f7f236564cef.png").read_bytes()
+
+
+class MockResponse(BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class MockOpener:
+    def __init__(
+        self,
+        data: bytes,
+        redirect_handler=None,
+        redirect_to: str | None = None,
+    ) -> None:
+        self.data = data
+        self.redirect_handler = redirect_handler
+        self.redirect_to = redirect_to
+        self.last_timeout = None
+
+    def open(self, url: str, timeout=None):
+        self.last_timeout = timeout
+        if self.redirect_to:
+            assert self.redirect_handler is not None
+            self.redirect_handler.redirect_request(
+                Request(url), None, 302, "Found", {}, self.redirect_to
+            )
+        return MockResponse(self.data)
+
+
+def _mock_addrinfo_for(*addresses: str):
+    addrinfo = []
+    for address in addresses:
+        family = socket.AF_INET6 if ":" in address else socket.AF_INET
+        sockaddr = (address, 0, 0, 0) if family == socket.AF_INET6 else (address, 0)
+        addrinfo.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr))
+    return addrinfo
 
 
 def test_load_text_file():
@@ -67,3 +111,144 @@ def test_share_images_cache(tmp_path):
     with time_execution() as duration:
         build_pdf_with_big_images()
     assert duration.seconds < first_time_duration / 2
+
+
+def test_load_image_blocks_local_files_by_policy():
+    file = HERE / "__init__.py"
+    with pytest.raises(fpdf.FPDFResourceAccessError):
+        fpdf.image_parsing.load_image(
+            str(file), resource_access_policy=fpdf.ResourceAccessPolicy.NONE
+        )
+
+
+def test_load_image_allows_public_remote_by_default():
+    opener = MockOpener(PNG_BYTES)
+    with (
+        patch(
+            "fpdf.image_parsing.socket.getaddrinfo",
+            return_value=_mock_addrinfo_for("93.184.216.34"),
+        ),
+        patch(
+            "fpdf.image_parsing.build_opener",
+            side_effect=lambda handler: setattr(opener, "redirect_handler", handler)
+            or opener,
+        ),
+    ):
+        resource = fpdf.image_parsing.load_image("https://public.example/image.png")
+    assert resource.getvalue() == PNG_BYTES
+    assert opener.last_timeout == fpdf.image_parsing.SETTINGS.network_timeout
+
+
+def test_load_image_blocks_private_remote_by_default():
+    with patch(
+        "fpdf.image_parsing.socket.getaddrinfo",
+        return_value=_mock_addrinfo_for("127.0.0.1"),
+    ):
+        with pytest.raises(fpdf.FPDFResourceAccessError):
+            fpdf.image_parsing.load_image("http://private.example/image.png")
+
+
+def test_load_image_blocks_private_redirect_by_default():
+    def fake_getaddrinfo(host, *_args, **_kwargs):
+        if host == "public.example":
+            return _mock_addrinfo_for("93.184.216.34")
+        if host == "private.example":
+            return _mock_addrinfo_for("127.0.0.1")
+        raise AssertionError(f"Unexpected hostname: {host}")
+
+    with patch("fpdf.image_parsing.socket.getaddrinfo", side_effect=fake_getaddrinfo):
+        with patch(
+            "fpdf.image_parsing.build_opener",
+            side_effect=lambda handler: MockOpener(
+                PNG_BYTES,
+                redirect_handler=handler,
+                redirect_to="http://private.example/image.png",
+            ),
+        ):
+            with pytest.raises(fpdf.FPDFResourceAccessError):
+                fpdf.image_parsing.load_image("https://public.example/image.png")
+
+
+def test_image_per_call_policy_override_allows_private_remote():
+    pdf = fpdf.FPDF()
+    pdf.resource_access_policy = fpdf.ResourceAccessPolicy.NONE
+    pdf.add_page()
+    with (
+        patch(
+            "fpdf.image_parsing.socket.getaddrinfo",
+            return_value=_mock_addrinfo_for("127.0.0.1"),
+        ),
+        patch(
+            "fpdf.image_parsing.build_opener",
+            side_effect=lambda handler: MockOpener(PNG_BYTES, redirect_handler=handler),
+        ),
+    ):
+        pdf.image(
+            "http://private.example/image.png",
+            x=10,
+            y=10,
+            w=10,
+            resource_access_policy=fpdf.ResourceAccessPolicy.ALL,
+        )
+
+
+def test_svg_image_per_call_policy_override_applies_to_nested_resources(tmp_path):
+    svg_path = tmp_path / "nested.svg"
+    svg_path.write_text(
+        """
+        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        <image href="http://private.example/image.png" x="0" y="0" width="10" height="10"/>
+        </svg>""",
+        encoding="utf-8",
+    )
+
+    pdf = fpdf.FPDF()
+    pdf.resource_access_policy = fpdf.ResourceAccessPolicy.NONE
+    pdf.add_page()
+    with (
+        patch(
+            "fpdf.image_parsing.socket.getaddrinfo",
+            return_value=_mock_addrinfo_for("127.0.0.1"),
+        ),
+        patch(
+            "fpdf.image_parsing.build_opener",
+            side_effect=lambda handler: MockOpener(PNG_BYTES, redirect_handler=handler),
+        ),
+    ):
+        pdf.image(
+            svg_path,
+            w=10,
+            resource_access_policy=fpdf.ResourceAccessPolicy.ALL,
+        )
+
+
+def test_write_html_uses_document_resource_access_policy():
+    img_path = HERE / "png_images/c636287a4d7cb1a36362f7f236564cef.png"
+    pdf = fpdf.FPDF()
+    pdf.resource_access_policy = fpdf.ResourceAccessPolicy.NONE
+    pdf.add_page()
+    with pytest.raises(fpdf.FPDFResourceAccessError):
+        pdf.write_html(f'<img src="{img_path}" width="10" height="10">')
+
+
+def test_template_image_uses_document_resource_access_policy():
+    img_path = HERE / "png_images/c636287a4d7cb1a36362f7f236564cef.png"
+    pdf = fpdf.FPDF()
+    pdf.resource_access_policy = fpdf.ResourceAccessPolicy.NONE
+    pdf.add_page()
+    template = fpdf.FlexTemplate(
+        pdf,
+        elements=[
+            {
+                "name": "img",
+                "type": "I",
+                "x1": 10,
+                "y1": 10,
+                "x2": 20,
+                "y2": 20,
+                "text": str(img_path),
+            }
+        ],
+    )
+    with pytest.raises(fpdf.FPDFResourceAccessError):
+        template.render()

--- a/test/image/test_load_image.py
+++ b/test/image/test_load_image.py
@@ -9,11 +9,17 @@ from urllib.request import Request
 import pytest
 
 import fpdf
+from fpdf.image_datastructures import ImageCache
 
 from test.conftest import assert_pdf_equal, ensure_rss_memory_below, time_execution
 
 HERE = Path(__file__).resolve().parent
 PNG_BYTES = (HERE / "png_images/c636287a4d7cb1a36362f7f236564cef.png").read_bytes()
+SIMPLE_SVG_WITH_REMOTE_IMAGE = b"""
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <image href="https://public.example/image.png" x="0" y="0" width="10" height="10"/>
+</svg>
+"""
 
 
 class MockResponse(BytesIO):
@@ -169,6 +175,31 @@ def test_load_image_blocks_private_redirect_by_default():
                 fpdf.image_parsing.load_image("https://public.example/image.png")
 
 
+def test_svg_preload_preserves_resource_access_error_for_blocked_redirect():
+    def fake_getaddrinfo(host, *_args, **_kwargs):
+        if host == "public.example":
+            return _mock_addrinfo_for("93.184.216.34")
+        if host == "private.example":
+            return _mock_addrinfo_for("127.0.0.1")
+        raise AssertionError(f"Unexpected hostname: {host}")
+
+    with (
+        patch("fpdf.image_parsing.socket.getaddrinfo", side_effect=fake_getaddrinfo),
+        patch(
+            "fpdf.image_parsing.build_opener",
+            side_effect=lambda handler: MockOpener(
+                b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>',
+                redirect_handler=handler,
+                redirect_to="http://private.example/image.svg",
+            ),
+        ),
+    ):
+        with pytest.raises(fpdf.FPDFResourceAccessError):
+            fpdf.image_parsing.preload_image(
+                ImageCache(), "https://public.example/image.svg"
+            )
+
+
 def test_image_per_call_policy_override_allows_private_remote():
     pdf = fpdf.FPDF()
     pdf.resource_access_policy = fpdf.ResourceAccessPolicy.NONE
@@ -222,6 +253,28 @@ def test_svg_image_per_call_policy_override_applies_to_nested_resources(tmp_path
         )
 
 
+def test_svg_object_draw_to_page_uses_document_resource_access_policy():
+    svg = fpdf.svg.SVGObject(SIMPLE_SVG_WITH_REMOTE_IMAGE)
+    pdf = fpdf.FPDF()
+    pdf.resource_access_policy = fpdf.ResourceAccessPolicy.NONE
+    pdf.add_page()
+
+    with (
+        patch(
+            "fpdf.image_parsing.socket.getaddrinfo",
+            return_value=_mock_addrinfo_for("93.184.216.34"),
+        ),
+        patch(
+            "fpdf.image_parsing.build_opener",
+            side_effect=lambda handler: MockOpener(PNG_BYTES, redirect_handler=handler),
+        ),
+    ):
+        with pytest.raises(fpdf.FPDFResourceAccessError):
+            svg.draw_to_page(pdf)
+
+    assert svg.resource_access_policy == fpdf.ResourceAccessPolicy.DEFAULT
+
+
 def test_write_html_uses_document_resource_access_policy():
     img_path = HERE / "png_images/c636287a4d7cb1a36362f7f236564cef.png"
     pdf = fpdf.FPDF()
@@ -252,3 +305,47 @@ def test_template_image_uses_document_resource_access_policy():
     )
     with pytest.raises(fpdf.FPDFResourceAccessError):
         template.render()
+
+
+def test_text_columns_downscale_reload_uses_document_resource_access_policy():
+    def fake_getaddrinfo(host, *_args, **_kwargs):
+        if host == "public.example":
+            return _mock_addrinfo_for("93.184.216.34")
+        if host == "private.example":
+            return _mock_addrinfo_for("127.0.0.1")
+        raise AssertionError(f"Unexpected hostname: {host}")
+
+    open_count = {"count": 0}
+
+    class RedirectOnSecondOpen:
+        def __init__(self, redirect_handler) -> None:
+            self.redirect_handler = redirect_handler
+
+        def open(self, url: str, timeout=None):  # pylint: disable=unused-argument
+            open_count["count"] += 1
+            if open_count["count"] == 2:
+                self.redirect_handler.redirect_request(
+                    Request(url),
+                    None,
+                    302,
+                    "Found",
+                    {},
+                    "http://private.example/image.png",
+                )
+            return MockResponse(PNG_BYTES)
+
+    pdf = fpdf.FPDF()
+    pdf.resource_access_policy = fpdf.ResourceAccessPolicy.REMOTE_PUBLIC
+    pdf.oversized_images = "downscale"
+    pdf.add_page()
+
+    with (
+        patch("fpdf.image_parsing.socket.getaddrinfo", side_effect=fake_getaddrinfo),
+        patch(
+            "fpdf.image_parsing.build_opener",
+            side_effect=RedirectOnSecondOpen,
+        ),
+    ):
+        with pytest.raises(fpdf.FPDFResourceAccessError):
+            with pdf.text_columns() as cols:
+                cols.image("https://public.example/image.png", width=1, height=1)


### PR DESCRIPTION
This PR adds a configurable `resource_access_policy` to control which local and remote resources fpdf2 may load while rendering documents.

The new policy is intended to reduce accidental local file access and unwanted outbound network requests when applications render user-provided or partially trusted content.

**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] A unit test is covering the code added / modified by this PR

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [ ] A mention of the change is present in `CHANGELOG.md`

- [ ] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->

<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
