### PR TITLE
fix(text_region): prevent font state leaking out of text_columns rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * fix page order after dry-run of `FPDF.multi_cell` in ToC - _cf._ [issue #1836](https://github.com/py-pdf/fpdf2/issues/1836)
 * rendering SVG arcs with very small sweeps that previously rounded to zero - _cf._ [issue #1831](https://github.com/py-pdf/fpdf2/issues/1831)
 * number of surviving escape characters - __cf.__ [issue #1215](https://github.com/py-pdf/fpdf2/issues/1215)
+* restore font state after a `text_columns()` / `text_region()` context exits - _cf._ [issue #1804](https://github.com/py-pdf/fpdf2/issues/1804)
 ### Changed
 * skip byte-for-byte compressed data comparison when zlib-ng is detected, regardless of OS
 

--- a/fpdf/text_region.py
+++ b/fpdf/text_region.py
@@ -432,7 +432,16 @@ class ParagraphCollectorMixin(ABC):
         self.pdf.clear_text_region()
         self.pdf.page = self._page
         self.pdf._pop_local_stack()  # pyright: ignore[reportPrivateUsage]
-        self.render()
+        # Rendering mutates the font state per fragment; restore it afterwards (issue #1804).
+        saved_font = self.pdf.current_font
+        saved_font_size_pt = self.pdf.font_size_pt
+        saved_font_style = self.pdf.font_style
+        try:
+            self.render()
+        finally:
+            self.pdf.current_font = saved_font
+            self.pdf.font_size_pt = saved_font_size_pt
+            self.pdf.font_style = saved_font_style
 
     def _check_paragraph(self) -> None:
         if self._active_paragraph == "EXPLICIT":

--- a/test/text_region/test_text_columns.py
+++ b/test/text_region/test_text_columns.py
@@ -391,3 +391,17 @@ def test_text_columns_with_shorter_2nd_column(tmp_path):  # issue 1442
     pdf.write(text="More text after columns.")
     pdf.ln()
     assert_pdf_equal(pdf, HERE / "text_columns_with_shorter_2nd_column.pdf", tmp_path)
+
+
+def test_text_columns_does_not_leak_font_state():  # issue 1804
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=12)
+    with pdf.text_columns() as cols:
+        pdf.set_font("Helvetica", size=24)
+        with cols.paragraph() as par:
+            par.write("Large heading")
+        pdf.set_font("Helvetica", size=10)
+        with cols.paragraph() as par:
+            par.write("Small body text")
+    assert pdf.font_size_pt == 12


### PR DESCRIPTION
Fixes #1804

The render path inside `_render_styled_text_line` mutates `self.font_size_pt` to match each fragment but never restores it, so `text_columns()` leaves the FPDF instance with the font size of the last rendered fragment. Snapshot `current_font`, `font_size_pt`, and `font_style` at the start of `TextColumns.render()` and restore them in a `finally` block.

**Checklist**:

- [x] A unit test is covering the code added / modified by this PR

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the \`docs/\` folder

- [x] A mention of the change is present in \`CHANGELOG.md\`

- [x] This PR is ready to be merged

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).