### PR TITLE
Fix actions workflow errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ test = [
   "brotli",
   "camelot-py",
   "endesive",
+  "pypdf",
   "pytest",
   "pytest-cov",
   "qrcode",

--- a/test/errors/test_deprecation_warnings.py
+++ b/test/errors/test_deprecation_warnings.py
@@ -23,7 +23,10 @@ def test_TitleStyle_deprecation():
 def test_add_font_uni_deprecation():
     pdf = FPDF()
 
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(
+        DeprecationWarning,
+        match=r'"uni" parameter is deprecated since v2\.5\.1 and will be removed in a future release',
+    ):
         # pylint: disable=unexpected-keyword-arg
         pdf.add_font(
             "DejaVu",
@@ -31,19 +34,14 @@ def test_add_font_uni_deprecation():
             HERE.parent / "fonts" / "DejaVuSans.ttf",
             uni=True,
         )
-    assert (
-        str(record[0].message)
-        == '"uni" parameter is deprecated since v2.5.1 and will be removed in a future release'
-    )
 
 
 def test_output_dest_deprecation():
     pdf = FPDF()
 
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(
+        DeprecationWarning,
+        match=r'"dest" parameter is deprecated since v2\.2\.0 and will be removed in a future release',
+    ):
         # pylint: disable=unexpected-keyword-arg
         pdf.output(dest="S")
-    assert (
-        str(record[0].message)
-        == '"dest" parameter is deprecated since v2.2.0 and will be removed in a future release'
-    )


### PR DESCRIPTION
- Add `pypdf` as `test` dependency - used to be added indirectly as `camelot` dependency before.

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
