### PR TITLE
fix: set_font() early-return skips current_font restore when font state diverges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * rendering SVG arcs with very small sweeps that previously rounded to zero - _cf._ [issue #1831](https://github.com/py-pdf/fpdf2/issues/1831)
 * number of surviving escape characters - __cf.__ [issue #1215](https://github.com/py-pdf/fpdf2/issues/1215)
 * leading spaces on new lines inside `<pre>` and `<pre><code>` blocks are no longer dropped - _cf._ [issue #1063](https://github.com/py-pdf/fpdf2/issues/1063)
+* `FPDF.set_font()` can restore `current_font` when the selected font state diverged - _cf._ [PR #1872](https://github.com/py-pdf/fpdf2/pull/1872)
 ### Changed
 * skip byte-for-byte compressed data comparison when zlib-ng is detected, regardless of OS
 

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -2664,15 +2664,16 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             size = self.font_size_pt
 
         # Test if font is already selected
+        fontkey = family + style
         if (
             self.font_family == family
             and self.font_style == style
             and FloatTolerance.equal(self.font_size_pt, size)
+            and (self.current_font is None or self.current_font.fontkey == fontkey)
         ):
             return
 
         # Test if used for the first time
-        fontkey = family + style
         if fontkey not in self.fonts:
             if fontkey not in CORE_FONTS:
                 raise FPDFException(

--- a/test/fonts/test_set_font.py
+++ b/test/fonts/test_set_font.py
@@ -176,3 +176,36 @@ def test_set_font_zapfdingbats_symbol_with_style():
 
                 # Test if underline is set correctly
                 assert pdf.underline == int("U" in style)
+
+
+def test_set_font_restores_current_font_after_state_divergence():
+    """
+    Regression test for gh-1488: set_font() must not early-return when font_family
+    matches the requested family but current_font has diverged (e.g. after fallback
+    font rendering sets self.current_font to the fallback font object while leaving
+    self.font_family pointing to the primary font).
+    """
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=12)
+    # Register Times so it can be used below.
+    pdf.set_font("Times", size=12)
+    times_font = pdf.current_font
+
+    # Simulate the divergent state: font_family says 'helvetica' but
+    # current_font is the Times object (as happens when a fallback font
+    # was the last font written to the page content stream).
+    pdf.font_family = "helvetica"
+    pdf.font_style = ""
+    pdf.font_size_pt = 12
+    pdf.current_font = times_font
+
+    assert pdf.font_family == "helvetica"
+    assert pdf.current_font.fontkey == "times"
+
+    # set_font("Helvetica") must restore current_font to helvetica, not return early.
+    pdf.set_font("Helvetica", size=12)
+    assert pdf.current_font.fontkey == "helvetica", (
+        f"set_font() returned early due to matching font_family, "
+        f"but current_font was not restored (got {pdf.current_font.fontkey!r})"
+    )


### PR DESCRIPTION
## Problem

`set_font()` has an early-return guard that fires when `font_family`, `font_style`, and `font_size_pt` all match the requested values. However it does not check whether `current_font` is consistent with those high-level attributes.

When a fallback font is rendered (see line ~4167 in `fpdf.py`), the code updates `self.current_font` to the fallback font object while leaving `self.font_family` pointing to the primary font. After rendering, calling `set_font('primary')` finds `font_family == 'primary'` (match), `font_style == ''` (match), and `font_size_pt` (match), so it returns early **without** restoring `current_font` back to the primary font object.

This is the root cause of #1488: subsequent PDF rendering uses the stale fallback `current_font`.

## Fix

Add `self.current_font.fontkey == fontkey` to the early-return condition. When `current_font` has diverged from `font_family` (inconsistent state), the guard no longer fires and `set_font()` proceeds through its full logic to select the correct font.

As a minor cleanup, `fontkey = family + style` is now computed once before the early-return check (instead of again immediately after).

## Test

Added `test_set_font_restores_current_font_after_state_divergence` in `test/fonts/test_set_font.py` that:
1. Creates the divergent state by setting `font_family = 'helvetica'` while `current_font = times_font`  
2. Calls `set_font('Helvetica')` and asserts `current_font.fontkey == 'helvetica'`

The test fails on the old code and passes with this fix.

This pull request was prepared with the assistance of AI, under my direction and review.