### PR TITLE
Fix spurious "Not enough horizontal space" error with fragmented text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * preserve markdown format in `FPDF.multi_cell` in dry-run - _cf._ [issue #1840](https://github.com/py-pdf/fpdf2/issues/1840)
 * fix page order after dry-run of `FPDF.multi_cell` in ToC - _cf._ [issue #1836](https://github.com/py-pdf/fpdf2/issues/1836)
 * rendering SVG arcs with very small sweeps that previously rounded to zero - _cf._ [issue #1831](https://github.com/py-pdf/fpdf2/issues/1831)
+* spurious "Not enough horizontal space to render a single character" error when text without break opportunities is split into many small fragments, e.g. by a fallback font alternating with the main font - _cf._ [issue #1250](https://github.com/py-pdf/fpdf2/issues/1250)
 * number of surviving escape characters - __cf.__ [issue #1215](https://github.com/py-pdf/fpdf2/issues/1215)
 * leading spaces on new lines inside `<pre>` and `<pre><code>` blocks are no longer dropped - _cf._ [issue #1063](https://github.com/py-pdf/fpdf2/issues/1063)
 * `FPDF.set_font()` can restore `current_font` when the selected font state diverged - _cf._ [PR #1872](https://github.com/py-pdf/fpdf2/pull/1872)

--- a/fpdf/line_break.py
+++ b/fpdf/line_break.py
@@ -745,7 +745,11 @@ class MultiLineBreak:
         self.skip_leading_spaces = skip_leading_spaces
         self.fragment_index: int = 0
         self.character_index: int = 0
-        self.idx_last_forced_break: Optional[int] = None
+        # (fragment_index, character_index) of the last forced break. Both
+        # indices are needed: with heavily fragmented text (e.g. a fallback
+        # font alternating with the main font), consecutive lines can break at
+        # the same character index within *different* fragments (issue #1250).
+        self.idx_last_forced_break: Optional[Tuple[int, int]] = None
         self.first_line_indent = first_line_indent
         self._is_first_line = True
 
@@ -848,11 +852,17 @@ class MultiLineBreak:
                     ) = current_line.automatic_break(self.align)
                     self.character_index += 1
                     return line
-                if idx_last_forced_break == self.character_index:
+                if idx_last_forced_break == (
+                    self.fragment_index,
+                    self.character_index,
+                ):
                     raise FPDFException(
                         "Not enough horizontal space to render a single character"
                     )
-                self.idx_last_forced_break = self.character_index
+                self.idx_last_forced_break = (
+                    self.fragment_index,
+                    self.character_index,
+                )
                 return current_line.manual_break(
                     Align.L if self.align == Align.J else self.align,
                 )

--- a/test/text/test_line_break.py
+++ b/test/text/test_line_break.py
@@ -1483,3 +1483,50 @@ def test_substitution_fragments_are_not_merged_with_base_fragments():
     assert line.fragments == [fragment_before, substitution_fragment, fragment_after]
 
     assert multi_line_break.get_line() is None
+
+
+def test_forced_break_across_many_small_fragments():  # issue #1250
+    """
+    Text without any break opportunity can be split into many small fragments
+    (as happens when a fallback font alternates with the main font).
+    Consecutive lines are then force-broken at the same character index
+    within *different* fragments, which must not raise
+    "Not enough horizontal space to render a single character".
+    """
+    char_width = 6
+    test_width = char_width * 3
+    alphabet = {
+        "normal": {},
+    }
+    for char in "abcde":
+        alphabet["normal"][char] = char_width
+    graphics_state = gs_with_font(_gs_normal, alphabet["normal"])
+    fragments = [
+        FxFragment(characters, graphics_state, 1, None, alphabet)
+        for characters in ("aa", "b", "cc", "d", "ee")
+    ]
+    multi_line_break = MultiLineBreak(fragments, test_width, [0, 0])
+    lines = []
+    while (line := multi_line_break.get_line()) is not None:
+        lines.append("".join("".join(frag.characters) for frag in line.fragments))
+    assert lines == ["aab", "ccd", "ee"]
+
+
+def test_character_wider_than_line_raises():
+    """A single character wider than the line must still raise."""
+    char_width = 50
+    test_width = 20
+    alphabet = {
+        "normal": {"x": char_width, "y": char_width},
+    }
+    fragments = [
+        FxFragment(
+            "xy", gs_with_font(_gs_normal, alphabet["normal"]), 1, None, alphabet
+        )
+    ]
+    multi_line_break = MultiLineBreak(fragments, test_width, [0, 0])
+    with pytest.raises(FPDFException) as error:
+        for _ in range(10):
+            if multi_line_break.get_line() is None:
+                break
+    assert "Not enough horizontal space" in str(error.value)


### PR DESCRIPTION
Fixes #1250

## Problem

With two overlapping CJK fonts (main + fallback), text is split into many small fragments at every font switch. When such text (no break opportunities) is laid out in a narrow table cell, `MultiLineBreak.get_line()` raises a spurious:

```
FPDFException: Not enough horizontal space to render a single character
```

even though every line successfully rendered characters.

## Root cause

The no-progress guard compares only character indices:

```python
if idx_last_forced_break == self.character_index:
    raise FPDFException(...)
self.idx_last_forced_break = self.character_index
```

but `character_index` is relative to the *current fragment*, and the guard never records which fragment the previous forced break happened in. With many small fragments, consecutive lines can legitimately break at the same character index within **different** fragments (e.g. index 0 of fragment 2, then index 0 of fragment 4) — real progress, false alarm.

Reproduced deterministically at the unit level: fragments `("aa", "b", "cc", "d", "ee")` with a 3-character line width force-break at char index 0 in different fragments; on `master` this raises after rendering only `"aab"`.

## Fix

Record `(fragment_index, character_index)` for the last forced break, so the guard fires only when the break position truly did not advance. A single character genuinely wider than the line still raises (covered by a new test).

**Checklist**:

- [x] The GitHub pipeline is OK (green), meaning that both `pylint` (static code analyzer) and `black` (code formatter) are happy with the changes of this PR.
- [x] A unit test is covering the code added / modified by this PR — `test_forced_break_across_many_small_fragments` fails on `master` and passes with this change; `test_character_wider_than_line_raises` locks the still-intended error case. Full `test/text/` suite passes (163 passed).
- [x] This PR is ready to be merged. In its current state it can be merged into the `master` branch of the fpdf2 repository.
- [x] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder — not a new feature.
- [x] A mention of the change is present in `CHANGELOG.md`.

By submitting this pull request, I confirm that my contribution is made under the terms of the GNU LGPL 3.0 license.