### PR TITLE
Add SVG complexity limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ### Added
 * Punjabi (pa) tutorial translation - thanks to @Pawansingh3889
 * basic support for SVG `<symbol>` elements in the SVG parser
+* `FPDF.svg_limits` and `SVGLimits` to configure SVG complexity limits while rendering SVG images
 * `resource_access_policy` and [Security considerations](https://py-pdf.github.io/fpdf2/Security.html) documentation
 * [`FPDF.optional_content()`](https://py-pdf.github.io/fpdf2/OptionalContent.html) context manager to mark content as visible on screen only or in print only, using PDF Optional Content Groups - _cf._ [issue #441](https://github.com/py-pdf/fpdf2/issues/441), based on a recipe by @digidigital
 ### Fixed
@@ -40,6 +41,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * `FPDF.set_font()` can restore `current_font` when the selected font state diverged - _cf._ [PR #1872](https://github.com/py-pdf/fpdf2/pull/1872)
 * embed CID-keyed CFF fonts as raw CFF programs so browser PDF viewers render them correctly - _cf._ [issue #1874](https://github.com/py-pdf/fpdf2/issues/1874)
 * fixed broken links on documentation not directly leading to the API reference - _cf._ [issue #1876](https://github.com/py-pdf/fpdf2/issues/1876)
+* reject SVG `<use>` cycles and excessive nested expansion to prevent resource exhaustion in `FPDF.image()`
 ### Changed
 * skip byte-for-byte compressed data comparison when zlib-ng is detected, regardless of OS
 

--- a/docs/SVG.md
+++ b/docs/SVG.md
@@ -24,6 +24,59 @@ pdf.output("doc-with-svg.pdf")
 Either the embedded `.svg` file must includes `width` and/or `height` attributes (absolute or relative),
 or some dimensions must be provided to `.image()` through its `w=` and/or `h=` parameters.
 
+## SVG complexity limits ##
+
+`fpdf2` applies configurable SVG complexity limits while converting SVG content
+to PDF drawing paths. These limits are intended to prevent small, malicious SVG
+files from consuming excessive CPU or memory through deeply nested or repeated
+`<use>` references.
+
+The limits are configured on the `FPDF` instance:
+
+```python
+from fpdf import FPDF
+from fpdf.svg import SVGLimits
+
+pdf = FPDF()
+pdf.svg_limits = SVGLimits(
+    max_use_depth=64,
+    max_resolved_elements=500_000,
+)
+```
+
+The default limits are suitable for typical SVG input. If a trusted SVG is
+larger than the defaults allow, applications can raise the limits. A limit can
+also be disabled with `None`, but this should only be done for trusted SVG
+content:
+
+```python
+from fpdf import FPDF
+from fpdf.svg import SVGLimits
+
+pdf = FPDF()
+pdf.svg_limits = SVGLimits(
+    max_use_depth=None,
+    max_resolved_elements=None,
+)
+```
+
+When an SVG exceeds the configured limits, `fpdf2` raises
+`fpdf.errors.FPDFSvgLimitExceeded`:
+
+```python
+from fpdf import FPDF
+from fpdf.errors import FPDFSvgLimitExceeded
+
+pdf = FPDF()
+pdf.add_page()
+
+try:
+    pdf.image("vector.svg")
+except FPDFSvgLimitExceeded:
+    # Reject the SVG, ask the user to simplify it, or retry only if trusted.
+    ...
+```
+
 ## Detailed example ##
 
 The following script will create a PDF that consists only of the graphics

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -27,6 +27,67 @@ For example, SVG/XML parsing uses hardened XML handling intended to mitigate cla
 
 These protections reduce risk in specific parsing paths, but they do not replace safe application design or input validation.
 
+## SVG complexity limits
+
+To reduce the risk of CPU and memory exhaustion while rendering SVG files,
+`fpdf2` applies configurable SVG complexity limits through `FPDF.svg_limits`.
+
+By default, SVG rendering limits:
+
+* nested SVG `<use>` reference depth
+* the number of drawing elements after SVG references are resolved
+
+If an SVG exceeds those limits, `fpdf2` raises
+`fpdf.errors.FPDFSvgLimitExceeded`. Applications that accept user-provided SVGs
+can catch this exception and reject the input without relying on exception
+message matching:
+
+```python
+from fpdf import FPDF
+from fpdf.errors import FPDFSvgLimitExceeded
+
+pdf = FPDF()
+pdf.add_page()
+
+try:
+    pdf.image(user_svg_bytes, w=100)
+except FPDFSvgLimitExceeded:
+    # Reject the SVG, ask the user to simplify it, or retry only if trusted.
+    ...
+```
+
+Trusted applications that need to render unusually large SVGs can raise the
+limits for a document:
+
+```python
+from fpdf import FPDF
+from fpdf.svg import SVGLimits
+
+pdf = FPDF()
+pdf.svg_limits = SVGLimits(
+    max_use_depth=64,
+    max_resolved_elements=500_000,
+)
+```
+
+Each limit can be disabled with `None`, but this should only be done for trusted
+SVG input:
+
+```python
+from fpdf import FPDF
+from fpdf.svg import SVGLimits
+
+pdf = FPDF()
+pdf.svg_limits = SVGLimits(
+    max_use_depth=None,
+    max_resolved_elements=None,
+)
+```
+
+Disabling or substantially raising SVG limits can allow a small SVG to consume
+large amounts of CPU and memory. Keep the defaults for untrusted or partially
+trusted SVG input.
+
 ## Resource access policy
 
 To reduce the risk of unintended local file access or outbound network requests, `fpdf2` provides a configurable `resource_access_policy`.
@@ -69,6 +130,11 @@ pdf.image(
 
 This override also applies to nested raster resources referenced from SVG files loaded through that `image()` call.
 
+The resource access policy does not limit inline SVG expansion. An SVG that only
+uses internal references, such as `<use href="#shape">`, can still be rejected
+by SVG complexity limits even when `resource_access_policy` allows no external
+resources.
+
 ## Recommended usage
 
 When an application may handle user-provided or partially trusted content, prefer keeping the document-wide `resource_access_policy` restrictive and using per-call overrides only for specific trusted resources.
@@ -78,6 +144,7 @@ This is safer than relaxing the main policy for the entire `FPDF` instance.
 Recommended pattern:
 
 * keep `pdf.resource_access_policy` as strict as practical
+* keep the default `pdf.svg_limits` for user-provided SVG content
 * use `image(..., resource_access_policy=...)` only where a specific trusted resource needs broader access
 * avoid changing the global policy to accommodate a single image source
 
@@ -88,6 +155,7 @@ This is especially important in applications that expose PDF generation features
 Applications using `fpdf2` with untrusted input should also consider:
 
 * sanitizing or rejecting untrusted HTML and SVG content
+* catching `FPDFSvgLimitExceeded` and treating it as rejected SVG input
 * validating image paths and URLs before passing them to `fpdf2`
 * applying network egress restrictions at the infrastructure level
 * limiting filesystem access for the process running PDF generation

--- a/fpdf/errors.py
+++ b/fpdf/errors.py
@@ -62,3 +62,7 @@ class ComplianceError(FPDFException):
 
 class PDFAComplianceError(ComplianceError):
     """Raised when an operation would produce a PDF that violates the selected PDF/A profile."""
+
+
+class FPDFSvgLimitExceeded(FPDFException):
+    """Raised when an SVG file exceeds the configured limits for use depth or resolved elements."""

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -5400,6 +5400,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             name,
             dims,
             resource_access_policy=resource_access_policy,
+            svg_limits=self.svg_limits,
         )
         if isinstance(info, VectorImageInfo):
             return self._vector_image(
@@ -5741,6 +5742,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             name,  # pyright: ignore[reportArgumentType, reportReturnType]
             dims,
             resource_access_policy=self.resource_access_policy,
+            svg_limits=self.svg_limits,
         )
 
     def preload_glyph_image(self, glyph_image_bytes: bytes | BinaryIO) -> tuple[
@@ -5753,6 +5755,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
             name=glyph_image_bytes,
             dims=None,  # pyright: ignore[reportArgumentType, reportReturnType]
             resource_access_policy=self.resource_access_policy,
+            svg_limits=self.svg_limits,
         )
 
     @check_page

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -164,7 +164,12 @@ from .pattern import Gradient
 from .recorder import FPDFRecorder
 from .sign import Signature
 from .structure_tree import StructElem, StructureTreeBuilder
-from .svg import Percent, SVGObject, apply_svg_transform_to_user_space_gradients
+from .svg import (
+    Percent,
+    SVGObject,
+    SVGLimits,
+    apply_svg_transform_to_user_space_gradients,
+)
 from .syntax import DestinationXYZ, Name, PDFArray, PDFDate, PDFString
 from .table import Table, draw_box_borders
 from .text_region import TextColumns, TextRegionMixin
@@ -355,6 +360,7 @@ class FPDF(GraphicsStateMixin, TextRegionMixin):
         self.embedded_files: list[PDFEmbeddedFile] = []  # array of PDFEmbeddedFile
         self.image_cache = ImageCache()
         self.resource_access_policy = ResourceAccessPolicy.DEFAULT
+        self.svg_limits: SVGLimits = SVGLimits()
         self.in_footer = False  # flag set while rendering footer
         # indicates that we are inside an .unbreakable() code block:
         self._in_unbreakable = False

--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -41,7 +41,7 @@ from .image_datastructures import (
     RasterImageInfo,
     VectorImageInfo,
 )
-from .svg import SVGObject
+from .svg import SVGObject, SVGLimits
 from .util import ImageType
 
 try:
@@ -354,6 +354,7 @@ def preload_image(
     name: ImageType,
     dims: Optional[tuple[float, float]] = None,
     resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
+    svg_limits: Optional[SVGLimits] = None,
 ) -> tuple[
     str,
     Union[SVGObject, "PILImage", bytes, BinaryIO, Path, None],
@@ -399,8 +400,11 @@ def preload_image(
                 load_image(name, resource_access_policy=resource_access_policy),
                 image_cache=image_cache,
                 resource_access_policy=resource_access_policy,
+                svg_limits=svg_limits,
             )
         except FPDFResourceAccessError:
+            raise
+        except FPDFException:
             raise
         except Exception as error:
             raise ValueError(f"Could not parse file: {name}") from error
@@ -410,6 +414,7 @@ def preload_image(
             io.BytesIO(name),
             image_cache=image_cache,
             resource_access_policy=resource_access_policy,
+            svg_limits=svg_limits,
         )
     if isinstance(name, io.BytesIO) and _is_svg(name.getvalue().strip()):
         return get_svg_info(
@@ -417,6 +422,7 @@ def preload_image(
             name,
             image_cache=image_cache,
             resource_access_policy=resource_access_policy,
+            svg_limits=svg_limits,
         )
 
     # Load raster data.
@@ -556,6 +562,7 @@ def get_svg_info(
     img: BinaryIO,
     image_cache: ImageCache,
     resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
+    svg_limits: Optional[SVGLimits] = None,
 ) -> tuple[str, SVGObject, VectorImageInfo]:
     img.seek(0)
     svg_data = img.read()
@@ -563,6 +570,7 @@ def get_svg_info(
         svg_data,
         image_cache=image_cache,
         resource_access_policy=resource_access_policy,
+        svg_limits=svg_limits,
     )
     if svg.viewbox:
         _, _, w, h = svg.viewbox

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -15,6 +15,7 @@ import math
 import re
 import warnings
 from copy import deepcopy
+from dataclasses import dataclass
 from os import PathLike
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional
 
@@ -105,6 +106,31 @@ def _normalize_css_value(value: Optional[str]) -> Optional[str]:
 @force_nodocument
 class Percent(float):
     """class to represent percentage values"""
+
+
+@dataclass(frozen=True)
+class SVGLimits:
+    """
+    Configurable limits for SVG processing.
+
+    A limit set to None disables that specific check. Disabling or raising limits
+    should only be done for SVG input from trusted sources.
+    """
+
+    max_use_depth: int | None = 32
+    "Maximum depth allowed while resolving nested SVG <use> references."
+
+    max_resolved_elements: int | None = 100_000
+    "Maximum number of elements allowed after resolving SVG <use> references."
+
+    def __post_init__(self) -> None:
+        self._validate_limit("max_use_depth", self.max_use_depth)
+        self._validate_limit("max_resolved_elements", self.max_resolved_elements)
+
+    @staticmethod
+    def _validate_limit(name: str, value: int | None) -> None:
+        if value is not None and value <= 0:
+            raise ValueError(f"{name} must be a positive integer or None")
 
 
 unit_splitter = re.compile(r"\s*(?P<value>[-+]?[\d\.]+)\s*(?P<unit>%|[a-zA-Z]*)")

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -1020,8 +1020,6 @@ class SVGObject:
             for element in root_tag.iter()
             if (element_id := element.attrib.get("id"))
         }
-        memo: dict[int, int] = {}
-        active_refs: set[str] = set()
 
         def use_ref(use_tag: "Element") -> Optional[str]:
             for candidate in xmlns_lookup("xlink", "href", "id"):
@@ -1029,9 +1027,22 @@ class SVGObject:
                     return use_tag.attrib[candidate]
             return None
 
-        def max_nested_use_depth(element: "Element") -> int:
+        max_use_depth = self.svg_limits.max_use_depth
+        memo: dict[int, int] = {}
+        active_refs: set[str] = set()
+
+        def check_use_depth(depth: int) -> None:
+            if max_use_depth is not None and depth > max_use_depth:
+                raise FPDFSvgLimitExceeded(
+                    "SVG complexity exceeds the configured "
+                    f"max_use_depth limit ({max_use_depth})"
+                )
+
+        def max_nested_use_depth(element: "Element", current_depth: int = 0) -> int:
+            check_use_depth(current_depth)
             element_id = id(element)
             if element_id in memo:
+                check_use_depth(current_depth + memo[element_id])
                 return memo[element_id]
             depth = 0
             for child in element.iter():
@@ -1048,25 +1059,20 @@ class SVGObject:
                         f"SVG <use> reference cycle detected for {ref!r}"
                     )
                 active_refs.add(ref)
-                depth = max(depth, 1 + max_nested_use_depth(referenced))
-                active_refs.remove(ref)
+                try:
+                    depth = max(
+                        depth,
+                        1 + max_nested_use_depth(referenced, current_depth + 1),
+                    )
+                finally:
+                    active_refs.remove(ref)
+                check_use_depth(current_depth + depth)
             memo[element_id] = depth
             return depth
 
-        max_use_depth = self.svg_limits.max_use_depth
         for referenced_element in elements_by_id.values():
-            depth = max_nested_use_depth(referenced_element)
-            if max_use_depth is not None and depth > max_use_depth:
-                raise FPDFSvgLimitExceeded(
-                    "SVG complexity exceeds the configured "
-                    f"max_use_depth limit ({max_use_depth})"
-                )
-        root_depth = max_nested_use_depth(root_tag)
-        if max_use_depth is not None and root_depth > max_use_depth:
-            raise FPDFSvgLimitExceeded(
-                "SVG complexity exceeds the configured "
-                f"max_use_depth limit ({max_use_depth})"
-            )
+            max_nested_use_depth(referenced_element)
+        max_nested_use_depth(root_tag)
 
         max_resolved_elements = self.svg_limits.max_resolved_elements
         if max_resolved_elements is None:

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -30,6 +30,7 @@ from .enums import (
     ResourceAccessPolicy,
     StrokeCapStyle,
 )
+from .errors import FPDFSvgLimitExceeded
 
 try:
     from defusedxml.ElementTree import fromstring as parse_xml_str
@@ -131,6 +132,12 @@ class SVGLimits:
     def _validate_limit(name: str, value: int | None) -> None:
         if value is not None and value <= 0:
             raise ValueError(f"{name} must be a positive integer or None")
+
+
+def _resolved_element_cost(item: Any) -> int:
+    if isinstance(item, GraphicsContext):
+        return 1 + sum(_resolved_element_cost(child) for child in item.path_items)
+    return 1
 
 
 unit_splitter = re.compile(r"\s*(?P<value>[-+]?[\d\.]+)\s*(?P<unit>%|[a-zA-Z]*)")
@@ -963,10 +970,14 @@ class SVGObject:
         svg_text: str | bytes,
         image_cache: Optional[ImageCache] = None,
         resource_access_policy: ResourceAccessPolicy = ResourceAccessPolicy.DEFAULT,
+        svg_limits: Optional[SVGLimits] = None,
     ) -> None:
         self.image_cache = image_cache  # Needed to render images
         self.resource_access_policy = resource_access_policy
+        self.svg_limits = svg_limits or SVGLimits()
+        self._resolved_element_count = 0
         self.cross_references: dict[str, Any] = {}
+        self._cross_reference_costs: dict[str, int] = {}
         self.symbol_info: dict[str, SymbolInfo] = {}
         self.css_class_styles: dict[str, dict[str, Any]] = {}
         self.gradient_definitions: dict[str, GradientPaint] = (
@@ -982,6 +993,7 @@ class SVGObject:
 
         self._collect_css_styles(svg_tree)
         self.extract_shape_info(svg_tree)
+        self._check_svg_limits(svg_tree)
         self.convert_graphics(svg_tree)
 
     @force_nodocument
@@ -989,6 +1001,140 @@ class SVGObject:
         if key:
             key = "#" + key if not key.startswith("#") else key
             self.cross_references[key] = referenced
+            self._cross_reference_costs[key] = _resolved_element_cost(referenced)
+
+    def _record_resolved_elements(self, count: int) -> None:
+        max_resolved_elements = self.svg_limits.max_resolved_elements
+        if max_resolved_elements is None:
+            return
+        if self._resolved_element_count + count > max_resolved_elements:
+            raise FPDFSvgLimitExceeded(
+                "SVG complexity exceeds the configured "
+                f"max_resolved_elements limit ({max_resolved_elements})"
+            )
+        self._resolved_element_count += count
+
+    def _check_svg_limits(self, root_tag: "Element") -> None:
+        elements_by_id = {
+            f"#{element_id}": element
+            for element in root_tag.iter()
+            if (element_id := element.attrib.get("id"))
+        }
+        memo: dict[int, int] = {}
+        active_refs: set[str] = set()
+
+        def use_ref(use_tag: "Element") -> Optional[str]:
+            for candidate in xmlns_lookup("xlink", "href", "id"):
+                if candidate in use_tag.attrib:
+                    return use_tag.attrib[candidate]
+            return None
+
+        def max_nested_use_depth(element: "Element") -> int:
+            element_id = id(element)
+            if element_id in memo:
+                return memo[element_id]
+            depth = 0
+            for child in element.iter():
+                if child.tag not in xmlns_lookup("svg", "use"):
+                    continue
+                ref = use_ref(child)
+                if not ref:
+                    continue
+                referenced = elements_by_id.get(ref)
+                if referenced is None:
+                    continue
+                if ref in active_refs:
+                    raise FPDFSvgLimitExceeded(
+                        f"SVG <use> reference cycle detected for {ref!r}"
+                    )
+                active_refs.add(ref)
+                depth = max(depth, 1 + max_nested_use_depth(referenced))
+                active_refs.remove(ref)
+            memo[element_id] = depth
+            return depth
+
+        max_use_depth = self.svg_limits.max_use_depth
+        for referenced_element in elements_by_id.values():
+            depth = max_nested_use_depth(referenced_element)
+            if max_use_depth is not None and depth > max_use_depth:
+                raise FPDFSvgLimitExceeded(
+                    "SVG complexity exceeds the configured "
+                    f"max_use_depth limit ({max_use_depth})"
+                )
+        root_depth = max_nested_use_depth(root_tag)
+        if max_use_depth is not None and root_depth > max_use_depth:
+            raise FPDFSvgLimitExceeded(
+                "SVG complexity exceeds the configured "
+                f"max_use_depth limit ({max_use_depth})"
+            )
+
+        max_resolved_elements = self.svg_limits.max_resolved_elements
+        if max_resolved_elements is None:
+            return
+
+        graphic_container_tags = xmlns_lookup("svg", "svg", "symbol", "g", "a")
+        graphic_leaf_tags = xmlns_lookup("svg", "path", "image", "text") | shape_tags
+        defs_tags = xmlns_lookup("svg", "defs")
+        clip_path_tags = xmlns_lookup("svg", "clipPath")
+        style_tags = xmlns_lookup("svg", "style")
+        gradient_tags = xmlns_lookup("svg", "linearGradient", "radialGradient")
+        use_tags = xmlns_lookup("svg", "use")
+        projected_cost_memo: dict[int, int] = {}
+        active_projected_refs: set[str] = set()
+
+        def check_projected_limit(cost: int) -> int:
+            if cost > max_resolved_elements:
+                raise FPDFSvgLimitExceeded(
+                    "SVG complexity exceeds the configured "
+                    f"max_resolved_elements limit ({max_resolved_elements})"
+                )
+            return cost
+
+        def projected_cost(element: "Element") -> int:
+            element_id = id(element)
+            if element_id in projected_cost_memo:
+                return projected_cost_memo[element_id]
+
+            if element.tag in use_tags:
+                ref = use_ref(element)
+                if ref is None:
+                    return 1
+                referenced = elements_by_id.get(ref)
+                if referenced is None:
+                    return 1
+                if ref in active_projected_refs:
+                    raise FPDFSvgLimitExceeded(
+                        f"SVG <use> reference cycle detected for {ref!r}"
+                    )
+                active_projected_refs.add(ref)
+                cost = 1 + projected_cost(referenced)
+                active_projected_refs.remove(ref)
+            elif element.tag in graphic_container_tags:
+                cost = 1
+                defs_cost = sum(
+                    projected_cost(child) for child in element if child.tag in defs_tags
+                )
+                # build_group() currently handles <defs> before normal children, then
+                # encounters the same <defs> again while iterating over children.
+                cost += defs_cost
+                for child in element:
+                    cost += projected_cost(child)
+                    check_projected_limit(cost)
+            elif element.tag in defs_tags:
+                cost = sum(projected_cost(child) for child in element)
+            elif element.tag in clip_path_tags:
+                cost = sum(projected_cost(child) for child in element)
+            elif element.tag in graphic_leaf_tags:
+                cost = 1
+            elif element.tag in style_tags or element.tag in gradient_tags:
+                cost = 0
+            else:
+                cost = 0
+
+            projected_cost_memo[element_id] = check_projected_limit(cost)
+            return cost
+
+        projected_cost(root_tag)
 
     def _collect_css_styles(self, root_tag: "Element") -> None:
         for node in root_tag.iter():
@@ -1607,11 +1753,14 @@ class SVGObject:
             raise ValueError(f"use {xref} doesn't contain known xref attribute")
 
         try:
-            pdf_group.add_item(self.cross_references[ref])
+            referenced = self.cross_references[ref]
+            referenced_cost = self._cross_reference_costs[ref]
         except KeyError:
             raise ValueError(
                 f"use {xref} references nonexistent ref id {ref}"
             ) from None
+        self._record_resolved_elements(1 + referenced_cost)
+        pdf_group.add_item(referenced)
 
         placement_transform = None
         if "x" in xref.attrib or "y" in xref.attrib:
@@ -1659,6 +1808,7 @@ class SVGObject:
         merged_style.update(local_style)
         if pdf_group is None:
             pdf_group = GraphicsContext()
+        self._record_resolved_elements(1)
         apply_styles(pdf_group, group, merged_style)
 
         # handle defs before anything else
@@ -1709,6 +1859,7 @@ class SVGObject:
     @force_nodocument
     def build_path(self, path: "Element") -> PaintedPath:
         """Convert an SVG <path> tag into a PDF path object."""
+        self._record_resolved_elements(1)
         style_map = self._style_map_for(path)
         pdf_path = PaintedPath()
         apply_styles(pdf_path, path, style_map)
@@ -1723,6 +1874,7 @@ class SVGObject:
     @force_nodocument
     def build_shape(self, shape: "Element") -> PaintedPath:
         """Convert an SVG shape tag into a PDF path object. Necessary to make xref (because ShapeBuilder doesn't have access to this object.)"""
+        self._record_resolved_elements(1)
         style_map = self._style_map_for(shape)
         shape_builder = getattr(ShapeBuilder, shape_tags[shape.tag])
         shape_path = shape_builder(shape)
@@ -1736,11 +1888,13 @@ class SVGObject:
     @force_nodocument
     def build_clipping_path(self, shape: "Element", clip_id: Optional[str]) -> None:
         if shape.tag in shape_tags:
+            self._record_resolved_elements(1)
             style_map = self._style_map_for(shape)
             shape_builder = getattr(ShapeBuilder, shape_tags[shape.tag])
             clipping_path_shape = shape_builder(shape, True)
             apply_styles(clipping_path_shape, shape, style_map)
         elif shape.tag in xmlns_lookup("svg", "path"):
+            self._record_resolved_elements(1)
             style_map = self._style_map_for(shape)
             clipping_path_shape = PaintedPath()
             apply_styles(clipping_path_shape, shape, style_map)
@@ -1775,6 +1929,7 @@ class SVGObject:
 
     @force_nodocument
     def build_image(self, image: "Element") -> "SVGImage":
+        self._record_resolved_elements(1)
         href = None
         for key in xmlns_lookup("xlink", "href"):
             if key in image.attrib:
@@ -1818,6 +1973,7 @@ class SVGObject:
         - Honors x/y and dx/dy on <text> and direct child <tspan>
         - Flattens nested tspans; advanced per-character positioning is not implemented
         """
+        self._record_resolved_elements(1)
         local_style = self._style_map_for(text_tag)
         effective_style = dict(inherited_style or {})
         effective_style.update(local_style)
@@ -2047,6 +2203,7 @@ class SVGImage(NamedTuple):
             image_cache,
             self.href,
             resource_access_policy=self.svg_obj.resource_access_policy,
+            svg_limits=self.svg_obj.svg_limits,
         )
         if isinstance(info, VectorImageInfo):
             LOGGER.warning(

--- a/fpdf/text_region.py
+++ b/fpdf/text_region.py
@@ -302,6 +302,7 @@ class ImageParagraph:
             self.region.pdf.image_cache,
             self.name,
             resource_access_policy=self.region.pdf.resource_access_policy,
+            svg_limits=self.region.pdf.svg_limits,
         )
         return self
 

--- a/test/svg/test_svg_limits.py
+++ b/test/svg/test_svg_limits.py
@@ -1,7 +1,21 @@
+from pathlib import Path
+
 import pytest
 
 import fpdf
-from fpdf.svg import SVGLimits
+from fpdf.errors import FPDFSvgLimitExceeded
+from fpdf.svg import SVGObject, SVGLimits
+
+
+def _nested_use_svg(level: int, fanout: int = 2) -> bytes:
+    groups = ['<g id="g0"><rect width="1" height="1"/></g>']
+    for current_level in range(1, level + 1):
+        uses = f'<use href="#g{current_level - 1}"/>' * fanout
+        groups.append(f'<g id="g{current_level}">{uses}</g>')
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+        "<defs>" + "".join(groups) + f'</defs><use href="#g{level}"/></svg>'
+    ).encode()
 
 
 def test_fpdf_has_default_svg_limits() -> None:
@@ -42,3 +56,52 @@ def test_svg_limits_accept_disabled_limits() -> None:
 
     assert limits.max_use_depth is None
     assert limits.max_resolved_elements is None
+
+
+def test_svg_limits_reject_use_cycles() -> None:
+    svg = b"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">
+      <defs>
+        <g id="a"><use href="#b"/></g>
+        <g id="b"><use href="#a"/></g>
+      </defs>
+      <use href="#a"/>
+    </svg>
+    """
+
+    with pytest.raises(fpdf.FPDFException, match="cycle"):
+        SVGObject(svg)
+
+
+def test_svg_limits_reject_excessive_use_depth() -> None:
+    with pytest.raises(FPDFSvgLimitExceeded, match="max_use_depth"):
+        SVGObject(_nested_use_svg(level=2), svg_limits=SVGLimits(max_use_depth=1))
+
+
+def test_fpdf_image_uses_svg_resolved_element_limit() -> None:
+    pdf = fpdf.FPDF()
+    pdf.add_page()
+    pdf.svg_limits = SVGLimits(max_resolved_elements=20)
+
+    with pytest.raises(fpdf.FPDFException, match="max_resolved_elements"):
+        pdf.image(_nested_use_svg(level=2, fanout=4), w=10)
+
+
+def test_fpdf_image_svg_file_preserves_limit_exception(tmp_path: Path) -> None:
+    svg_file = tmp_path / "heavy.svg"
+    svg_file.write_bytes(_nested_use_svg(level=2, fanout=4))
+    pdf = fpdf.FPDF()
+    pdf.add_page()
+    pdf.svg_limits = SVGLimits(max_resolved_elements=20)
+
+    with pytest.raises(fpdf.FPDFException, match="max_resolved_elements"):
+        pdf.image(svg_file, w=10)
+
+
+def test_svg_limits_can_disable_complexity_limits() -> None:
+    svg = SVGObject(
+        _nested_use_svg(level=3, fanout=4),
+        svg_limits=SVGLimits(max_use_depth=None, max_resolved_elements=None),
+    )
+
+    assert svg.base_group is not None

--- a/test/svg/test_svg_limits.py
+++ b/test/svg/test_svg_limits.py
@@ -18,7 +18,19 @@ def _nested_use_svg(level: int, fanout: int = 2) -> bytes:
     ).encode()
 
 
-def test_fpdf_has_default_svg_limits() -> None:
+def _reverse_nested_use_svg(level: int) -> bytes:
+    groups = [
+        f'<g id="g{current_level}"><use href="#g{current_level - 1}"/></g>'
+        for current_level in range(level, 0, -1)
+    ]
+    groups.append('<g id="g0"><rect width="1" height="1"/></g>')
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+        "<defs>" + "".join(groups) + f'</defs><use href="#g{level}"/></svg>'
+    ).encode()
+
+
+def test_default_svg_limits() -> None:
     pdf = fpdf.FPDF()
 
     assert isinstance(pdf.svg_limits, SVGLimits)
@@ -51,13 +63,6 @@ def test_svg_limits_reject_non_positive_resolved_elements(
         SVGLimits(max_resolved_elements=max_resolved_elements)
 
 
-def test_svg_limits_accept_disabled_limits() -> None:
-    limits = SVGLimits(max_use_depth=None, max_resolved_elements=None)
-
-    assert limits.max_use_depth is None
-    assert limits.max_resolved_elements is None
-
-
 def test_svg_limits_reject_use_cycles() -> None:
     svg = b"""
     <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">
@@ -78,7 +83,12 @@ def test_svg_limits_reject_excessive_use_depth() -> None:
         SVGObject(_nested_use_svg(level=2), svg_limits=SVGLimits(max_use_depth=1))
 
 
-def test_fpdf_image_uses_svg_resolved_element_limit() -> None:
+def test_svg_limits_reject_deep_reverse_ordered_use_chain() -> None:
+    with pytest.raises(FPDFSvgLimitExceeded, match="max_use_depth"):
+        SVGObject(_reverse_nested_use_svg(level=1100))
+
+
+def test_image_uses_svg_resolved_element_limit() -> None:
     pdf = fpdf.FPDF()
     pdf.add_page()
     pdf.svg_limits = SVGLimits(max_resolved_elements=20)
@@ -87,7 +97,7 @@ def test_fpdf_image_uses_svg_resolved_element_limit() -> None:
         pdf.image(_nested_use_svg(level=2, fanout=4), w=10)
 
 
-def test_fpdf_image_svg_file_preserves_limit_exception(tmp_path: Path) -> None:
+def test_image_preserves_limit_exception(tmp_path: Path) -> None:
     svg_file = tmp_path / "heavy.svg"
     svg_file.write_bytes(_nested_use_svg(level=2, fanout=4))
     pdf = fpdf.FPDF()
@@ -98,7 +108,7 @@ def test_fpdf_image_svg_file_preserves_limit_exception(tmp_path: Path) -> None:
         pdf.image(svg_file, w=10)
 
 
-def test_svg_limits_can_disable_complexity_limits() -> None:
+def test_disable_complexity_limits() -> None:
     svg = SVGObject(
         _nested_use_svg(level=3, fanout=4),
         svg_limits=SVGLimits(max_use_depth=None, max_resolved_elements=None),

--- a/test/svg/test_svg_limits.py
+++ b/test/svg/test_svg_limits.py
@@ -1,0 +1,44 @@
+import pytest
+
+import fpdf
+from fpdf.svg import SVGLimits
+
+
+def test_fpdf_has_default_svg_limits() -> None:
+    pdf = fpdf.FPDF()
+
+    assert isinstance(pdf.svg_limits, SVGLimits)
+    assert pdf.svg_limits == SVGLimits()
+
+
+def test_fpdf_svg_limits_can_be_replaced() -> None:
+    pdf = fpdf.FPDF()
+    custom_limits = SVGLimits(
+        max_use_depth=64,
+        max_resolved_elements=500_000,
+    )
+
+    pdf.svg_limits = custom_limits
+
+    assert pdf.svg_limits is custom_limits
+
+
+@pytest.mark.parametrize("max_use_depth", [0, -1])
+def test_svg_limits_reject_non_positive_use_depth(max_use_depth: int) -> None:
+    with pytest.raises(ValueError, match="must be a positive integer or None"):
+        SVGLimits(max_use_depth=max_use_depth)
+
+
+@pytest.mark.parametrize("max_resolved_elements", [0, -1])
+def test_svg_limits_reject_non_positive_resolved_elements(
+    max_resolved_elements: int,
+) -> None:
+    with pytest.raises(ValueError, match="must be a positive integer or None"):
+        SVGLimits(max_resolved_elements=max_resolved_elements)
+
+
+def test_svg_limits_accept_disabled_limits() -> None:
+    limits = SVGLimits(max_use_depth=None, max_resolved_elements=None)
+
+    assert limits.max_use_depth is None
+    assert limits.max_resolved_elements is None


### PR DESCRIPTION
Add configurable SVG complexity limits to prevent excessive CPU and memory use from deeply nested or repeated SVG `<use>` references.

This introduces `FPDF.svg_limits`, `SVGLimits`, and `FPDFSvgLimitExceeded`, rejects `<use>` cycles, and documents how trusted applications can raise or disable the limits.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- To check an item, place an "x" in the box like so: "- [x] Item description"
     Add "N/A" to the end of each line that's irrelevant to your changes -->

- [x] A unit test is covering the code added / modified by this PR

- [x] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder

- [x] A mention of the change is present in `CHANGELOG.md`

- [x] This PR is ready to be merged <!-- In your opinion, can this be merged as soon as it's reviewed? Else, this can be turned into a Draft PR -->

<!-- Feel free to add additional comments, and to ask questions if some of those guidelines are unclear to you! -->

<!--
Once a PR is merged, maintainers will add your name to the contributors table in README.md.
If they forget, or you do not wish this to happen, please mention it.
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
