### PR TITLE
Support SVG switch elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ### Added
 * Punjabi (pa) tutorial translation - thanks to @Pawansingh3889
 * basic support for SVG `<symbol>` elements in the SVG parser
+* basic support for SVG `<switch>` elements in the SVG parser - _cf._ [issue #537](https://github.com/py-pdf/fpdf2/issues/537)
 * `resource_access_policy` and [Security considerations](https://py-pdf.github.io/fpdf2/Security.html) documentation
 * [`FPDF.optional_content()`](https://py-pdf.github.io/fpdf2/OptionalContent.html) context manager to mark content as visible on screen only or in print only, using PDF Optional Content Groups - _cf._ [issue #441](https://github.com/py-pdf/fpdf2/issues/441), based on a recipe by @digidigital
 ### Fixed

--- a/docs/SVG.md
+++ b/docs/SVG.md
@@ -197,9 +197,10 @@ logging.getLogger("fpdf.svg").propagate = False
 - basic shapes (`<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polyline>`, `<polygon>`)
 - basic `<image>` elements
 - basic cross-references, with `defs` tags anywhere in the SVG code
+- basic `<switch>` elements, selecting the first child without conditional processing attributes
 - stroke & fill coloring and opacity
 - basic stroke styling
-- inline CSS styling via `style="..."` attributes
+- basic CSS styling via `style="..."` attributes and class rules in `<style>` tags
 - clipping paths
 - gradients: `<linearGradient>` and `<radialGradient>` elements with stops, opacity, transforms, and spread methods
 
@@ -215,13 +216,12 @@ rendering as a completely blank PDF.
 
 There are some common SVG features that are currently **unsupported**, but that `fpdf2` could end up supporting with the help of contributors :
 
-- `<tspan>` / `<textPath>` / `<text>` (-> there is a starting [draft PR](https://github.com/py-pdf/fpdf2/pull/1029))
-- `<symbol>`
 - `<marker>`
 - `<pattern>`
 - embedded non-image content (including nested SVGs)
+- `<textPath>`
 - many standard attributes
-- CSS styling via `<style>` tags or external *.css files.
+- complex CSS selectors or external *.css files.
 
 {==
 

--- a/fpdf/svg.py
+++ b/fpdf/svg.py
@@ -1502,6 +1502,8 @@ class SVGObject:
         for child in defs:
             if child.tag in xmlns_lookup("svg", "g"):
                 self.build_group(child)
+            elif child.tag in xmlns_lookup("svg", "switch"):
+                self.build_switch(child)
             elif child.tag in xmlns_lookup("svg", "symbol"):
                 self.build_symbol(child)
             elif child.tag in xmlns_lookup("svg", "a"):
@@ -1642,42 +1644,87 @@ class SVGObject:
             self.handle_defs(child)
 
         for child in group:
-            if child.tag in xmlns_lookup("svg", "defs"):
-                self.handle_defs(child)
-            elif child.tag in xmlns_lookup("svg", "style"):
-                # Stylesheets already parsed globally.
-                continue
-            elif child.tag in xmlns_lookup("svg", "symbol"):
-                self.build_symbol(child)
-            elif child.tag in xmlns_lookup("svg", "g"):
-                pdf_group.add_item(self.build_group(child, None, merged_style), False)
-            elif child.tag in xmlns_lookup("svg", "a"):
-                # <a> tags aren't supported but we need to recurse into them to
-                # render nested elements.
-                LOGGER.warning(
-                    "Ignoring unsupported SVG tag: <a> (contributions are welcome to add support for it)",
-                )
-                pdf_group.add_item(self.build_group(child, None, merged_style), False)
-            elif child.tag in xmlns_lookup("svg", "path"):
-                pdf_group.add_item(self.build_path(child), False)
-            elif child.tag in shape_tags:
-                pdf_group.add_item(self.build_shape(child), False)
-            elif child.tag in xmlns_lookup("svg", "use"):
-                pdf_group.add_item(self.build_xref(child), False)
-            elif child.tag in xmlns_lookup("svg", "image"):
-                pdf_group.add_item(self.build_image(child), False)
-            elif child.tag in xmlns_lookup("svg", "text"):
-                text_path = self.build_text(child, merged_style)
-                if text_path:
-                    pdf_group.add_item(text_path, False)
-            else:
-                LOGGER.warning(
-                    "Ignoring unsupported SVG tag: <%s> (contributions are welcome to add support for it)",
-                    without_ns(child.tag),
-                )
+            self._build_group_child(pdf_group, child, merged_style)
 
         self.update_xref(group.attrib.get("id"), pdf_group)
 
+        return pdf_group
+
+    @force_nodocument
+    def _build_group_child(
+        self,
+        pdf_group: GraphicsContext,
+        child: "Element",
+        inherited_style: dict[str, Any],
+    ) -> None:
+        """Convert one graphics child while preserving its parent's style."""
+        if child.tag in xmlns_lookup("svg", "defs"):
+            self.handle_defs(child)
+        elif child.tag in xmlns_lookup("svg", "style"):
+            # Stylesheets already parsed globally.
+            return
+        elif child.tag in xmlns_lookup("svg", "symbol"):
+            self.build_symbol(child)
+        elif child.tag in xmlns_lookup("svg", "g"):
+            pdf_group.add_item(self.build_group(child, None, inherited_style), False)
+        elif child.tag in xmlns_lookup("svg", "switch"):
+            pdf_group.add_item(self.build_switch(child, inherited_style), False)
+        elif child.tag in xmlns_lookup("svg", "a"):
+            # <a> tags aren't supported but we need to recurse into them to
+            # render nested elements.
+            LOGGER.warning(
+                "Ignoring unsupported SVG tag: <a> (contributions are welcome to add support for it)",
+            )
+            pdf_group.add_item(self.build_group(child, None, inherited_style), False)
+        elif child.tag in xmlns_lookup("svg", "path"):
+            pdf_group.add_item(self.build_path(child), False)
+        elif child.tag in shape_tags:
+            pdf_group.add_item(self.build_shape(child), False)
+        elif child.tag in xmlns_lookup("svg", "use"):
+            pdf_group.add_item(self.build_xref(child), False)
+        elif child.tag in xmlns_lookup("svg", "image"):
+            pdf_group.add_item(self.build_image(child), False)
+        elif child.tag in xmlns_lookup("svg", "text"):
+            text_path = self.build_text(child, inherited_style)
+            if text_path:
+                pdf_group.add_item(text_path, False)
+        else:
+            LOGGER.warning(
+                "Ignoring unsupported SVG tag: <%s> (contributions are welcome to add support for it)",
+                without_ns(child.tag),
+            )
+
+    @force_nodocument
+    def build_switch(
+        self, switch: "Element", inherited_style: Optional[dict[str, Any]] = None
+    ) -> GraphicsContext:
+        """Render the first ``<switch>`` child that needs no environment support.
+
+        Conditional SVG processing attributes need browser capabilities or user locale
+        preferences that fpdf2 does not expose. Children that use them are therefore
+        skipped, which allows a following unconditional fallback to be rendered.
+        """
+        local_style = self._style_map_for(switch)
+        merged_style = dict(inherited_style or {})
+        merged_style.update(local_style)
+        pdf_group = GraphicsContext()
+        apply_styles(pdf_group, switch, merged_style)
+
+        conditional_attributes = (
+            "requiredFeatures",
+            "requiredExtensions",
+            "systemLanguage",
+        )
+        for child in switch:
+            if any(attribute in child.attrib for attribute in conditional_attributes):
+                LOGGER.debug(
+                    "Skipping conditional <switch> child <%s>", without_ns(child.tag)
+                )
+                continue
+            self._build_group_child(pdf_group, child, merged_style)
+            break
+
+        self.update_xref(switch.attrib.get("id"), pdf_group)
         return pdf_group
 
     @force_nodocument

--- a/test/svg/test_svg.py
+++ b/test/svg/test_svg.py
@@ -311,6 +311,45 @@ class TestSVGObject:
 
         assert_pdf_equal(pdf, GENERATED_PDF_DIR / f"{svg_file.stem}.pdf", tmp_path)
 
+    def test_svg_switch_uses_the_first_unconditional_child(self):
+        svg_data = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+              <switch>
+                <rect width="10" height="10" />
+                <circle cx="5" cy="5" r="5" />
+              </switch>
+            </svg>
+        """
+
+        svg = fpdf.svg.SVGObject(svg_data)
+
+        switch_group = svg.base_group.path_items[0]
+        selected_shape = switch_group.path_items[0]
+        assert isinstance(selected_shape, fpdf.drawing.PaintedPath)
+        assert isinstance(
+            selected_shape._root_graphics_context.path_items[1],
+            fpdf.drawing.RoundedRectangle,
+        )
+
+    def test_svg_switch_skips_conditional_children_for_a_fallback(self):
+        svg_data = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+              <switch>
+                <rect requiredFeatures="http://example.invalid/feature" width="10" height="10" />
+                <circle cx="5" cy="5" r="5" />
+              </switch>
+            </svg>
+        """
+
+        svg = fpdf.svg.SVGObject(svg_data)
+
+        switch_group = svg.base_group.path_items[0]
+        selected_shape = switch_group.path_items[0]
+        assert isinstance(selected_shape, fpdf.drawing.PaintedPath)
+        assert isinstance(
+            selected_shape._root_graphics_context.path_items[1], fpdf.drawing.Ellipse
+        )
+
     def test_svg_rendering_image_over_page_break(self, tmp_path):
         pdf = fpdf.FPDF()
         pdf.add_page()


### PR DESCRIPTION
## Summary

- add basic SVG `<switch>` support
- select the first child without conditional processing attributes
- skip environment-dependent alternatives so an unconditional fallback can render
- update the SVG support documentation

## Why

`<switch>` was ignored by the SVG parser, causing SVGs that use fallback graphics to render blank in that section.

## Validation

- `ruff check fpdf/svg.py test/svg/test_svg.py`
- `python -m pytest test/svg/test_svg.py -q` (276 passed)

## Checklist

- [x] A unit test covers the change.
- [x] Documentation and changelog entries are included.
- [x] This pull request is ready for review.

By submitting this pull request, I confirm that my contribution is made under the terms of the GNU LGPL 3.0 license.
