### PR TITLE
fix: Paragraph.ln(h) no longer causes a double line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * reject SVG `<use>` cycles and excessive nested expansion to prevent resource exhaustion in `FPDF.image()`
 * count SVG `<switch>` elements in SVG complexity limits
 * declare the default base state and display order for Optional Content Groups so PDF viewers can list layers correctly - _cf._ [issue #1895](https://github.com/py-pdf/fpdf2/issues/1895)
+* `Paragraph.ln(h)` in a text region no longer adds an extra line break after the first line that follows it - _cf._ [issue #1786](https://github.com/py-pdf/fpdf2/issues/1786)
 ### Changed
 * skip byte-for-byte compressed data comparison when zlib-ng is detected, regardless of OS
 

--- a/fpdf/line_break.py
+++ b/fpdf/line_break.py
@@ -798,6 +798,11 @@ class MultiLineBreak:
         while self.fragment_index < len(self.fragments):
             current_fragment = self.fragments[self.fragment_index]
 
+            if self.character_index >= len(current_fragment.characters):
+                self.character_index = 0
+                self.fragment_index += 1
+                continue
+
             if FloatTolerance.greater_than(
                 current_fragment.font_size, current_font_height
             ):
@@ -808,11 +813,6 @@ class MultiLineBreak:
                     max_width -= float(margin)
                 if self._is_first_line:
                     max_width -= self.first_line_indent
-
-            if self.character_index >= len(current_fragment.characters):
-                self.character_index = 0
-                self.fragment_index += 1
-                continue
 
             character = current_fragment.characters[self.character_index]
             character_width = current_fragment.get_character_width(

--- a/test/text_region/test_text_columns.py
+++ b/test/text_region/test_text_columns.py
@@ -443,3 +443,23 @@ def test_text_columns_restore_page_font_after_context(tmp_path):
         HERE / "text_columns_restore_page_font_after_context.pdf",
         tmp_path,
     )
+
+
+def test_text_columns_ln_with_height_no_double_break():  # issue 1786
+    """`Paragraph.ln(h)` must not inflate the height of the following line.
+
+    The vertical gap is carried by a newline fragment whose font size is set
+    to `h`; once that fragment is consumed it must no longer contribute to the
+    height of the next line.
+    """
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=16)
+
+    with pdf.text_columns() as cols:
+        cols.write("A1\nA2")
+        cols.ln(16)
+        cols.write("B1\nB2")
+        heights = [lw.line.height for lw in cols._paragraphs[0].build_lines(False)]
+
+    assert heights[0] == heights[1] == heights[2] == heights[3]


### PR DESCRIPTION
Fixes #1786

`Paragraph.ln(h)` carries the requested gap by appending a newline fragment whose `font_size_pt` is set to `h`. In `MultiLineBreak.get_line()` the per-fragment font size was folded into `current_font_height` *before* the check that skips a fragment whose characters are already consumed, so the inflated newline fragment kept driving the height of the following line — producing an extra blank line after the first line of the next paragraph. Moving the exhausted-fragment check ahead of the font-size update keeps the requested gap while the next line uses the real font height.

**Checklist**:

- [x] A unit test is covering the code added / modified by this PR

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder — N/A

- [x] A mention of the change is present in `CHANGELOG.md`

- [x] This PR is ready to be merged

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
