### PR TITLE
fix(text_region): apply Paragraph.ln(h) height to the line it terminates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * basic support for SVG `<switch>` elements in the SVG parser - _cf._ [issue #537](https://github.com/py-pdf/fpdf2/issues/537)
 * support for keeping aspect ratio for images in templates - _cf._ [issue #1118](https://github.com/py-pdf/fpdf2/issues/1118)
 ### Fixed
+* custom height passed to `Paragraph.ln()` in a text region is now applied to the line it terminates instead of the first line of the following paragraph - _cf._ [issue #1786](https://github.com/py-pdf/fpdf2/issues/1786)
 * font state (family, style, size, current font, and the page-level "font is set" flag) no longer leaks back onto the `FPDF` instance after a `text_columns()` / `text_region()` context exits, so a subsequent `pdf.cell()` / `pdf.write()` renders at the caller's font instead of the last paragraph's - _cf._ [issue #1804](https://github.com/py-pdf/fpdf2/issues/1804)
 * text rendering when the first text on a page starts with a fallback glyph - _cf._ [issue #1772](https://github.com/py-pdf/fpdf2/issues/1772)
 * preserve boundary-neutral formatting during bidirectional text preprocessing - _cf._ [issue #1779](https://github.com/py-pdf/fpdf2/issues/1779)

--- a/fpdf/line_break.py
+++ b/fpdf/line_break.py
@@ -798,6 +798,11 @@ class MultiLineBreak:
         while self.fragment_index < len(self.fragments):
             current_fragment = self.fragments[self.fragment_index]
 
+            if self.character_index >= len(current_fragment.characters):
+                self.character_index = 0
+                self.fragment_index += 1
+                continue
+
             if FloatTolerance.greater_than(
                 current_fragment.font_size, current_font_height
             ):
@@ -809,11 +814,6 @@ class MultiLineBreak:
                 if self._is_first_line:
                     max_width -= self.first_line_indent
 
-            if self.character_index >= len(current_fragment.characters):
-                self.character_index = 0
-                self.fragment_index += 1
-                continue
-
             character = current_fragment.characters[self.character_index]
             character_width = current_fragment.get_character_width(
                 character, self.print_sh, initial_cs=not first_char
@@ -822,8 +822,13 @@ class MultiLineBreak:
 
             if character in (NEWLINE, FORM_FEED):
                 self.character_index += 1
-                if not current_line.fragments:
-                    current_line.height = current_font_height * self.line_height
+                # The fragment carrying the line break may request a larger
+                # height than the text it terminates (this is how
+                # Paragraph.ln(h) passes on a custom height), and that height
+                # belongs to this line rather than to the following one.
+                current_line.height = max(
+                    current_line.height, current_font_height * self.line_height
+                )
                 self._is_first_line = False
                 return current_line.manual_break(
                     Align.L if self.align == Align.J else self.align,

--- a/test/text_region/test_text_columns.py
+++ b/test/text_region/test_text_columns.py
@@ -443,3 +443,27 @@ def test_text_columns_restore_page_font_after_context(tmp_path):
         HERE / "text_columns_restore_page_font_after_context.pdf",
         tmp_path,
     )
+
+
+def test_tcols_ln_with_custom_height():
+    """Regression test for issue #1786.
+
+    Paragraph.ln(h) carries the custom height on the "\\n" fragment it
+    appends. That fragment is consumed by the line it terminates, but the
+    height was applied to the *following* line instead, so the extra spacing
+    appeared inside the next paragraph (between its first and second line)
+    rather than before it.
+    """
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=16)
+    with pdf.text_columns() as cols:
+        cols.write(text="A\nA")
+        cols.ln(16)
+        cols.write(text="B\nB")
+        heights = [w.line.height for w in cols._paragraphs[-1].build_lines(False)]
+
+    # The 16pt gap belongs to the line the ln() terminates (the 2nd "A"),
+    # not to the first line of the next paragraph.
+    assert heights[1] == 16
+    assert heights[2] == heights[3] == heights[0]


### PR DESCRIPTION
Fixes #1786

`Paragraph.ln(h)` passes a custom height by appending a `"\n"` fragment with its font size inflated to `h`. In `MultiLineBreak.get_line()` that height was only used when the line had no other fragments, so normally it was dropped from the line the break terminates; it then leaked onto the *next* line because `current_font_height` was raised from the already-consumed fragment before it was skipped. The result was the extra gap landing between the first and second line of the following paragraph instead of before it.

**Checklist**:

- [x] A unit test is covering the code added / modified by this PR

- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder — N/A

- [x] A mention of the change is present in `CHANGELOG.md`

- [x] This PR is ready to be merged

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
