### PR TITLE
Fix: catch RuntimeError alongside ImportError for the optional numpy import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 * basic support for SVG `<switch>` elements in the SVG parser - _cf._ [issue #537](https://github.com/py-pdf/fpdf2/issues/537)
 * support for keeping aspect ratio for images in templates - _cf._ [issue #1118](https://github.com/py-pdf/fpdf2/issues/1118)
 ### Fixed
+* the optional `numpy` import in `image_parsing.py` no longer crashes on CPUs unsupported by numpy's `manylinux` wheel baseline; `RuntimeError` is now treated the same as `ImportError`, so `numpy` degrades to unavailable instead of taking down `import fpdf` - _cf._ [issue #1908](https://github.com/py-pdf/fpdf2/issues/1908)
 * font state (family, style, size, current font, and the page-level "font is set" flag) no longer leaks back onto the `FPDF` instance after a `text_columns()` / `text_region()` context exits, so a subsequent `pdf.cell()` / `pdf.write()` renders at the caller's font instead of the last paragraph's - _cf._ [issue #1804](https://github.com/py-pdf/fpdf2/issues/1804)
 * text rendering when the first text on a page starts with a fallback glyph - _cf._ [issue #1772](https://github.com/py-pdf/fpdf2/issues/1772)
 * preserve boundary-neutral formatting during bidirectional text preprocessing - _cf._ [issue #1779](https://github.com/py-pdf/fpdf2/issues/1779)

--- a/fpdf/image_parsing.py
+++ b/fpdf/image_parsing.py
@@ -67,7 +67,7 @@ else:
 
 try:
     import numpy
-except ImportError:
+except (ImportError, RuntimeError):
     numpy = None  # type: ignore[assignment]
 
 


### PR DESCRIPTION
Fixes #1908

The optional `numpy` import in `image_parsing.py` only caught `ImportError`. On CPUs numpy's `manylinux` wheel doesn't support (below its `x86-64-v2` baseline as of numpy 2.4.0), `import numpy` raises `RuntimeError` instead, which propagated out of `import fpdf` entirely and crashed every caller, even ones that never touch the numpy-guarded code paths. Both existing call sites (`pack_codes_into_bytes()`, `_has_alpha()`) already guard on `numpy is not None`, so treating `RuntimeError` the same as `ImportError` is enough to restore the intended "numpy unavailable, fall back" behavior.

**Checklist**:

- [ ] A unit test is covering the code added / modified by this PR - N/A, this only widens an except clause around an import statement; reproducing it requires either genuinely unsupported hardware or monkeypatching `builtins.__import__`, none of which seem feasible or really useful
- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder
- [x] A mention of the change is present in `CHANGELOG.md`
- [x] This PR is ready to be merged

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
