### PR TITLE
fix(html): keep the <ul>/<ol> line-height stack balanced on an invalid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ in order to get warned about deprecated features used in your code.
 This can also be enabled programmatically with `warnings.simplefilter('default', DeprecationWarning)`.
 
 ## [2.8.9] - Not released yet
-
+### Fixed
+* `FPDF.write_html()` no longer raises `IndexError: pop from empty list` when a `<ul>` or `<ol>` element carries a `line-height` that is not a bare number (_e.g._ `line-height: normal` or `line-height: 1.5em`); such values are now ignored, and the default line height is used, consistently with `<p line-height="x">`
 
 ## [2.8.8] - 2026-08-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 
 ## [2.8.9] - Not released yet
 ### Fixed
-* `FPDF.write_html()` no longer raises `IndexError: pop from empty list` when a `<ul>` or `<ol>` element carries a `line-height` that is not a bare number (_e.g._ `line-height: normal` or `line-height: 1.5em`); such values are now ignored, and the default line height is used, consistently with `<p line-height="x">`
+* `FPDF.write_html()` no longer raises `IndexError: pop from empty list` when a `<ul>` or `<ol>` element carries a `line-height` that is not a bare number (_e.g._ `line-height: normal` or `line-height: 1.5em`); such values are now ignored, and the default line height is used, consistently with `<p line-height="x">` - _cf._ [PR #1917](https://github.com/py-pdf/fpdf2/pull/1917)
 
 ## [2.8.8] - 2026-08-09
 ### Added

--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -943,14 +943,15 @@ class HTML2FPDF(HTMLParser):
             # "line-height" attributes are not valid in HTML,
             # but we support it for backward compatibility,
             # because fpdf2 honors it since 2.6.1 and PR #629
+            line_height = None
             if line_height_str:
                 try:
                     # YYY parse and convert non-float line_height values
-                    self.line_height_stack.append(float(line_height_str))
+                    line_height = float(line_height_str)
                 except ValueError:
+                    # Invalid line-height: ignored, the default value is used
                     pass
-            else:
-                self.line_height_stack.append(None)
+            self.line_height_stack.append(line_height)
             if self.indent == 1:
                 tag_style = self.tag_styles[tag]
                 if isinstance(tag_style, TextStyle):
@@ -985,14 +986,15 @@ class HTML2FPDF(HTMLParser):
             # "line-height" attributes are not valid in HTML,
             # but we support it for backward compatibility,
             # because fpdf2 honors it since 2.6.1 and PR #629
+            line_height = None
             if line_height_str:
                 try:
                     # YYY parse and convert non-float line_height values
-                    self.line_height_stack.append(float(line_height_str))
+                    line_height = float(line_height_str)
                 except ValueError:
+                    # Invalid line-height: ignored, the default value is used
                     pass
-            else:
-                self.line_height_stack.append(None)
+            self.line_height_stack.append(line_height)
             if self.indent == 1:
                 tag_style = self.tag_styles[tag]
                 if isinstance(tag_style, TextStyle):

--- a/test/html/test_html.py
+++ b/test/html/test_html.py
@@ -925,6 +925,36 @@ def test_html_ol_ul_line_height(tmp_path):
     assert_pdf_equal(pdf, HERE / "html_ol_ul_line_height.pdf", tmp_path)
 
 
+def test_html_ol_ul_invalid_line_height(tmp_path):
+    # An invalid line-height on <ul> / <ol> must be ignored - just like on <p> -
+    # and render exactly like a list without any line-height:
+    def build(list_attrs, nested_attrs=""):
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.write_html(f"""<ul{list_attrs}>
+            <li>item</li>
+            <li>item
+                <ol{nested_attrs}>
+                    <li>nested item</li>
+                </ol>
+            </li>
+            <li>item</li>
+        </ul>
+        <ol{list_attrs}>
+            <li>item</li>
+        </ol>""")
+        return pdf
+
+    for attrs in (' style="line-height: normal"', ' line-height="1.5em"'):
+        assert_pdf_equal(build(attrs), build(""), tmp_path)
+    # A nested list must not consume its parent list line-height either:
+    assert_pdf_equal(
+        build(' line-height="2"', ' style="line-height: inherit"'),
+        build(' line-height="2"'),
+        tmp_path,
+    )
+
+
 def test_html_long_list_entries(tmp_path):
     pdf = FPDF()
     pdf.add_page()


### PR DESCRIPTION
### Problem

`HTML2FPDF.handle_starttag()` pushes onto `self.line_height_stack` only when the `line-height` value parses as a bare float:

```python
if line_height_str:
    try:
        self.line_height_stack.append(float(line_height_str))
    except ValueError:
        pass          # <- nothing pushed
else:
    self.line_height_stack.append(None)
```

but `handle_endtag()` pops it unconditionally for both list tags:

```python
if tag in ("ul", "ol"):
    ...
    self.line_height_stack.pop()
```

So any list carrying a `line-height` that is not a bare number — `normal`, `1.5em`, `inherit`, `120%`, … all perfectly valid CSS — leaves the stack one entry short:

* on a top-level list, `</ul>` pops an empty list → `IndexError: pop from empty list`
* on a nested list, `</ul>` pops the **enclosing** list's entry, so the remaining items of the outer list silently render at the wrong line height, and the outer end tag then raises the same `IndexError`

Reproducer on `master` (`0e9d95f`):

```python
from fpdf import FPDF

pdf = FPDF()
pdf.add_page()
pdf.set_font("helvetica", size=12)
pdf.write_html('<ul style="line-height: normal"><li>a</li></ul>')
```

```
  File ".../fpdf/html.py", line 1286, in handle_endtag
    self.line_height_stack.pop()
IndexError: pop from empty list
```

Same crash with `<ol style="line-height: 1.5em">` and with the legacy attribute form `<ul line-height="normal">`.

### Fix

Push exactly one entry per start tag, falling back to `None` (the default line height) when the value cannot be parsed. That is already the documented behaviour for paragraphs — `test_html_custom_line_height` covers `<p line-height="x">` with the comment *"invalid line-height ignored, default value of 1 will be used"* — so this only makes `<ul>`/`<ol>` consistent with `<p>`. Parsing non-float CSS values remains future work (the existing `# YYY` comment is untouched).

### Test

`test_html_ol_ul_invalid_line_height` asserts that a list with an unparseable `line-height` renders byte-identically to the same list without one, and that a nested list with an unparseable value does not disturb its parent's line height. It fails on `master` with the `IndexError` above and passes with this change.

```
$ python -m pytest test/html/ -q
90 passed
$ black --check .   # black 26.3.1, as pinned in .pre-commit-config.yaml
232 files would be left unchanged.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
