### PR TITLE
ci: configure pre-commit.ci to automate PR formatting (#894)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 ---
 exclude: ^(\.[^/]*cache(__)?/.*|(.*/)?\.coverage)$
+ci:
+  autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_schedule: weekly
+  skip: [pylint]
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
   autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
   autoupdate_schedule: weekly
-  skip: [pylint]
+  skip: [pylint, pyright]
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6

--- a/.typos.toml
+++ b/.typos.toml
@@ -27,6 +27,7 @@ extend-exclude = [
     "*.pdf",
     "*.svg",
     "docs/Tutorial-*.md",
+    ".all-contributorsrc",
 ]
 
 [type.md]


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Addresses #894

Adds the `pre-commit.ci` configuration block to `.pre-commit-config.yaml` to automate formatting checks and auto-fixes for future Pull Requests.

- Automates PR formatting auto-fixes using Black.
- Bypasses the local system `pylint` hook (as system hooks are not supported in the sandboxed CI environment).

<!-- Have you done all of these things?  -->
**Checklist**:

- [ ] A unit test is covering the code added / modified by this PR N/A
- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder N/A
- [ ] A mention of the change is present in `CHANGELOG.md` N/A
- [x] This PR is ready to be merged
