### PR TITLE
ci: workaround PyKCS11 build failure on Python 3.13+ (#1928)

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -52,7 +52,12 @@ jobs:
           python-version: 3.13 # guarddog / pygit2 still have issues with 3.14
       - name: Install Python dependencies ⚙️
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel swig
+          export CFLAGS="-DPyInt_FromLong=PyLong_FromLong"
+          export CXXFLAGS="-DPyInt_FromLong=PyLong_FromLong"
+          export CPPFLAGS="-DPyInt_FromLong=PyLong_FromLong"
+          export CL="-DPyInt_FromLong=PyLong_FromLong"
+          pip install --no-build-isolation endesive
           pip install --upgrade .[dev,test]
       # Running zizmor 1st, because it is blocking PR merge
       - name: Run zizmor 🌈
@@ -124,7 +129,7 @@ jobs:
         # for python 3.14
         shell: bash
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel swig
           # --- Create constraints file ---
           # For Python 3.14 only - temporary solution while camelot-py
           # update its dependencies
@@ -137,6 +142,11 @@ jobs:
             echo "Created empty $CONSTRAINTS_FILE"
           fi
           # --- Install dependencies respecting constraints ---
+          export CFLAGS="-DPyInt_FromLong=PyLong_FromLong"
+          export CXXFLAGS="-DPyInt_FromLong=PyLong_FromLong"
+          export CPPFLAGS="-DPyInt_FromLong=PyLong_FromLong"
+          export CL="-DPyInt_FromLong=PyLong_FromLong"
+          pip install --no-build-isolation endesive -c "$CONSTRAINTS_FILE"
           pip install --upgrade .[dev,test] -c "$CONSTRAINTS_FILE"
       - name: Run tests ☑
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This can also be enabled programmatically with `warnings.simplefilter('default',
 ## [2.8.9] - Not released yet
 ### Fixed
 * visual gap in rendering subsequent text after `{nb}` page alias when text shaping is enabled - _cf._ [issue #1090](https://github.com/py-pdf/fpdf2/issues/1090) - thanks to @prateek-dagar
+* workaround `PyKCS11` compilation failure under Python 3.13+ on CI by defining `CFLAGS`, `CXXFLAGS`, `CPPFLAGS`, and `CL` macros mapping `PyInt_FromLong` to `PyLong_FromLong` - _cf._ [issue #1928](https://github.com/py-pdf/fpdf2/issues/1928) - thanks to @prateek-dagar
 * `FPDF.write_html()` no longer raises `IndexError: pop from empty list` when a `<ul>` or `<ol>` element carries a `line-height` that is not a bare number (_e.g._ `line-height: normal` or `line-height: 1.5em`); such values are now ignored, and the default line height is used, consistently with `<p line-height="x">` - _cf._ [PR #1917](https://github.com/py-pdf/fpdf2/pull/1917)
 
 ## [2.8.8] - 2026-08-09


### PR DESCRIPTION
Addresses #1928  

#### **Problem**
On Python 3.13+, the `pykcs11` dependency of `endesive` fails to build from source on GHA Linux and Windows runners because it references `PyInt_FromLong`, which was removed in Python 3.13.

#### **Workaround**
1. Installs `swig` (pip package) during CI bootstrapping to support building without isolation.
2. Defines environment variables (`CFLAGS`, `CXXFLAGS`, `CPPFLAGS`, and `CL`) using `-D` to map `PyInt_FromLong` to `PyLong_FromLong`.
3. Installs `endesive` separately with `--no-build-isolation` to propagate the compiler flags.

> [!NOTE]
> This is a temporary workaround while the upstream PR in the [LudovicRousseau/PyKCS11 (PR)](https://github.com/LudovicRousseau/PyKCS11/pull/168) repository is merged and released.

**Checklist**:
- [x] Addresses #1928
- [x] Verified build success on Linux, macOS, and Windows runners
- [ ] In case of a new feature, docstrings have been added, with also some documentation in the `docs/` folder
- [x] A mention of the change is present in `CHANGELOG.md`
- [x] This PR is ready to be merged 

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
