### PR TITLE
Fix CI pipeline by pinning swig dev dependency - workaround for #1928

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -51,7 +51,11 @@ jobs:
         with:
           python-version: 3.13 # guarddog / pygit2 still have issues with 3.14
       - name: Install Python dependencies ⚙️
+        # Constraining swig version as a workaround for: https://github.com/py-pdf/fpdf2/issues/1928 / https://github.com/LudovicRousseau/PyKCS11/issues/167
+        env:
+          PIP_BUILD_CONSTRAINT: constraints.txt
         run: |
+          echo 'swig<4.5' > "$PIP_BUILD_CONSTRAINT"
           python -m pip install --upgrade pip setuptools wheel
           pip install --upgrade .[dev,test]
       # Running zizmor 1st, because it is blocking PR merge
@@ -120,24 +124,23 @@ jobs:
           choco install qpdf -y
           qpdf --version
       - name: Install Python dependencies ⚙️
-        # Temporarily writing a constraints file to make sure numpy 2.3.3 is used
-        # for python 3.14
+        # Temporarily writing a constraints file
+        # to make sure numpy 2.3.3 is used for Python 3.14
         shell: bash
+        env:
+          PIP_BUILD_CONSTRAINT: constraints.txt
         run: |
+          echo 'swig<4.5' > "$PIP_BUILD_CONSTRAINT"
           python -m pip install --upgrade pip setuptools wheel
           # --- Create constraints file ---
           # For Python 3.14 only - temporary solution while camelot-py
           # update its dependencies
-          CONSTRAINTS_FILE="constraints.txt"
           if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
-            echo "numpy>=2.3.3" > "$CONSTRAINTS_FILE"
-            echo "Added numpy>=2.3.3 to $CONSTRAINTS_FILE"
-          else
-            : > "$CONSTRAINTS_FILE"   # create empty file
-            echo "Created empty $CONSTRAINTS_FILE"
+            echo "numpy>=2.3.3" >> "$PIP_BUILD_CONSTRAINT"
+            echo "Added numpy>=2.3.3 to $PIP_BUILD_CONSTRAINT"
           fi
           # --- Install dependencies respecting constraints ---
-          pip install --upgrade .[dev,test] -c "$CONSTRAINTS_FILE"
+          pip install --upgrade .[dev,test]
       - name: Run tests ☑
         shell: bash
         env:

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -353,6 +353,17 @@ qpdf --qdf doc.pdf doc-qdf.pdf
 
 This is extremely useful to peek into the PDF document structure.
 
+### pdf-parser.py
+* [pdf-parser.py autonomous script on GitHub](https://github.com/DidierStevens/DidierStevensSuite/blob/master/pdf-parser.py)
+* [Documentation page on Didier Stevens blog](https://blog.didierstevens.com/programs/pdf-tools/)
+
+Usages examples :
+
+* display some stats on a PDF document: `pdf-parser.py file.pdf -a`
+* display a PDF document full structure: `pdf-parser.py file.pdf`
+* select only `Javascript` elements: `pdf-parser.py file.pdf -s Javascript`
+* extract a font file from object 9 in a PDF file: `pdf-parser.py file.pdf --object 9 --filter --dump dumped-9.ttf`
+
 ### pdfly
 `pdfly` is a very handy CLI tool to manipulate PDF files: [py-pdf/pdfly](https://github.com/py-pdf/pdfly?tab=readme-ov-file#usage).
 


### PR DESCRIPTION
This workaround was suggested in https://github.com/LudovicRousseau/PyKCS11/issues/167

I also added a mention of `pdf-parser.py` into `docs/Development.m`

By submitting this pull request, I confirm that my contribution is made under the terms of the [GNU LGPL 3.0 license](https://github.com/py-pdf/fpdf2/blob/master/LICENSE).
